### PR TITLE
Adding db.t3.micro max_connections

### DIFF
--- a/rds.go
+++ b/rds.go
@@ -22,6 +22,11 @@ var DBMaxConnections = map[string]map[string]int64{
 		"default":          150,
 		"default.mysql5.7": 150,
 	},
+	"db.t3.micro": map[string]int64{
+		"default":            112,
+		"default.postgres10": 112,
+		"default.postgres11": 112,
+	},
 	"db.m3.medium": map[string]int64{
 		"default": 392,
 	},


### PR DESCRIPTION
Amazon RDS Instance:
 - Model: db.t3.micro
 - Mem(GiB):1

RDS / Parameter groups / default.postgres11:
 - max_connections: LEAST({DBInstanceClassMemory/9531392},5000)

Calculations:
 - 1 GiB = 1073741824 bytes
 - 1073741824/9531392 = 112.65

Setting "db.t3.micro" max_connections to 112.

Signed-off-by: Amador Pahim <apahim@redhat.com>