### PR TITLE
Added db.r5.large max connections

### DIFF
--- a/rds.go
+++ b/rds.go
@@ -43,6 +43,12 @@ var DBMaxConnections = map[string]map[string]int64{
 		"default.postgres10": 823,
 		"default.postgres11": 823,
 	},
+	"db.r5.large": map[string]int64{
+		"default":            1802,
+		"default.postgres10": 1802,
+		"default.postgres11": 1802,
+		"default.postgres12": 1802,
+	},
 }
 
 // RDSExporter defines an instance of the RDS Exporter


### PR DESCRIPTION
Amazon RDS Instance:
 - Model: db.r5.large
 - Mem(GiB): 16

RDS / Parameter groups / default.postgres11:
 - max_connections: LEAST({DBInstanceClassMemory/9531392},5000)

Calculations:
 - 16 GiB = 17179869184 bytes
 - 17179869184/9531392 = 1802.45

Setting "db.r5.large" max_connections to 1802.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>