### PR TITLE
Adding db.t3.small max_connections

### DIFF
--- a/rds.go
+++ b/rds.go
@@ -27,6 +27,12 @@ var DBMaxConnections = map[string]map[string]int64{
 		"default.postgres10": 112,
 		"default.postgres11": 112,
 	},
+	"db.t3.small": map[string]int64{
+		"default":            225,
+		"default.postgres10": 225,
+		"default.postgres11": 225,
+		"default.postgres12": 225,
+	},
 	"db.m3.medium": map[string]int64{
 		"default": 392,
 	},


### PR DESCRIPTION
Amazon RDS Instance:
- Model: db.t3.small
- Mem(GiB): 2

RDS / Parameter groups / default.postgres11:
- max_connections: LEAST({DBInstanceClassMemory/9531392},5000)

Calculations:
- 2 GiB = 2147483648 bytes
- 2147483648/9531392 = 225.30

Setting "db.t3.small" max_connections to 225.

Signed-off-by: Amador Pahim <apahim@redhat.com>