### PR TITLE
Added db.m6g.large max connections

### DIFF
--- a/rds.go
+++ b/rds.go
@@ -55,6 +55,10 @@ var DBMaxConnections = map[string]map[string]int64{
 		"default.postgres11": 1802,
 		"default.postgres12": 1802,
 	},
+	"db.m6g.large": map[string]int64{
+		"default":            901,
+		"default.postgres12": 901,
+	},
 	"db.m6g.xlarge": map[string]int64{
 		"default":            1705,
 		"default.postgres10": 1705,


### PR DESCRIPTION
Amazon RDS Instance:
 - Model: db.m6g.large
 - Mem(GiB): 8

RDS / Parameter groups / default.postgres11:
 - max_connections: LEAST({DBInstanceClassMemory/9531392},5000)

Calculations:
 - 8 GiB = 8589934592 bytes
 - 8589934592/9531392 = 901.23

Setting "db.m6g.large" max_connections to 901.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>