### PR TITLE
Add support for tracking RDS pending maintenance actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ This was made as a complement to [CloudWatch Exporter](https://github.com/promet
 
 ## Included metadata & metrics
 
-| Service | Metric           | Description                           |
-|---------|------------------|---------------------------------------|
-| RDS     | allocatedstorage | The amount of allocated storage in GB |
-| RDS     | dbinstanceclass  | The DB instance class (type)          |
-| RDS     | dbinstancestatus | The instance status                   |
-| RDS     | engineversion    | The DB engine type and version        |
+| Service | Metric                    | Description                                               |
+|---------|---------------------------|-----------------------------------------------------------|
+| RDS     | allocatedstorage          | The amount of allocated storage in GB                     |
+| RDS     | dbinstanceclass           | The DB instance class (type)                              |
+| RDS     | dbinstancestatus          | The instance status                                       |
+| RDS     | engineversion             | The DB engine type and version                            |
+| RDS     | pendingmaintenanceactions | The number of pending maintenance actions for an instance |
+
 
 ## Running this software
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This was made as a complement to [CloudWatch Exporter](https://github.com/promet
 
 ## Included metadata & metrics
 
-| Service | Metric                    | Description                                               |
-|---------|---------------------------|-----------------------------------------------------------|
-| RDS     | allocatedstorage          | The amount of allocated storage in GB                     |
-| RDS     | dbinstanceclass           | The DB instance class (type)                              |
-| RDS     | dbinstancestatus          | The instance status                                       |
-| RDS     | engineversion             | The DB engine type and version                            |
-| RDS     | pendingmaintenanceactions | The number of pending maintenance actions for an instance |
+| Service | Metric                    | Description                                        |
+|---------|---------------------------|----------------------------------------------------|
+| RDS     | allocatedstorage          | The amount of allocated storage in GB              |
+| RDS     | dbinstanceclass           | The DB instance class (type)                       |
+| RDS     | dbinstancestatus          | The instance status                                |
+| RDS     | engineversion             | The DB engine type and version                     |
+| RDS     | pendingmaintenanceactions | The pending maintenance actions for a RDS instance |
 
 
 ## Running this software


### PR DESCRIPTION
Having information about RDS pending maintenance actions can be helpful in addition to the `engine_version` data for tracking database maintenance initiatives.

A database that doesn't require maintenance will look like this:

```
aws_resources_exporter_rds_pendingmaintenanceactions{action="",auto_apply_after="",aws_region="us-east-1",current_apply_date="",dbinstance_identifier="<some_identifier>",description=""} 0
```

And a database that requires maintenance will have a metric like:

```
aws_resources_exporter_rds_pendingmaintenanceactions{action="system-update",auto_apply_after="2022-06-30 00:00:00 +0000 UTC",aws_region="us-east-1",current_apply_date="2022-06-30 00:00:00 +0000 UTC",dbinstance_identifier="<some_identifier>",description="New Operating System update is available"} 1
```

## Testing

I executed this locally against an AWS account with >50 RDS instances:

* Confirmed that a metric was published for each RDS instance
* Confirmed that the metric was correctly identifying those instances needing maintenance or not