### PR TITLE
Fix metric collection for RDS pending maintenance actions

### DIFF
--- a/rds.go
+++ b/rds.go
@@ -395,16 +395,12 @@ func (e *RDSExporter) Collect(ch chan<- prometheus.Metric) {
 			instancesWithPendingMaint[dbIdentifier] = true
 
 			var autoApplyDate string
-			if action.AutoAppliedAfterDate == nil {
-				autoApplyDate = ""
-			} else {
+			if action.AutoAppliedAfterDate != nil {
 				autoApplyDate = action.AutoAppliedAfterDate.String()
 			}
 
 			var currentApplyDate string
-			if action.CurrentApplyDate == nil {
-				currentApplyDate = ""
-			} else {
+			if action.CurrentApplyDate != nil {
 				currentApplyDate = action.CurrentApplyDate.String()
 			}
 

--- a/rds.go
+++ b/rds.go
@@ -393,7 +393,22 @@ func (e *RDSExporter) Collect(ch chan<- prometheus.Metric) {
 			// DescribePendingMaintenanceActions only returns ARNs, so this gets the identifier.
 			dbIdentifier := strings.Split(*instance.ResourceIdentifier, ":")[6]
 			instancesWithPendingMaint[dbIdentifier] = true
-			ch <- prometheus.MustNewConstMetric(e.PendingMaintenanceActions, prometheus.GaugeValue, 1, *e.sess.Config.Region, dbIdentifier, *action.Action, action.AutoAppliedAfterDate.String(), action.CurrentApplyDate.String(), *action.Description)
+
+			var autoApplyDate string
+			if action.AutoAppliedAfterDate == nil {
+				autoApplyDate = ""
+			} else {
+				autoApplyDate = action.AutoAppliedAfterDate.String()
+			}
+
+			var currentApplyDate string
+			if action.CurrentApplyDate == nil {
+				currentApplyDate = ""
+			} else {
+				currentApplyDate = action.CurrentApplyDate.String()
+			}
+
+			ch <- prometheus.MustNewConstMetric(e.PendingMaintenanceActions, prometheus.GaugeValue, 1, *e.sess.Config.Region, dbIdentifier, *action.Action, autoApplyDate, currentApplyDate, *action.Description)
 		}
 	}
 


### PR DESCRIPTION
It appears that AutoAppliedAfterDate and CurrentApplyDate are optional
and AWS decided to remove these for some recent OS upgrades immediately
after I pushed this change.

**Testing**

Executed this change on an account with 50+ RDS instances. Verified that instances with and without apply date values now work:

```
# No apply date
aws_resources_exporter_rds_pendingmaintenanceactions{action="system-update",auto_apply_after="",aws_region="us-east-1",current_apply_date="",dbinstance_identifier="<some identifier>,description="Security and stability updates"} 1

# Apply date
aws_resources_exporter_rds_pendingmaintenanceactions{action="system-update",auto_apply_after="2022-08-31 00:00:00 +0000 UTC",aws_region="us-east-1",current_apply_date="2022-08-31 00:00:00 +0000 UTC",dbinstance_identifier="<some identifier>",description="New Operating System update is available"} 1
```