### PR TITLE
Gather RDS logs related metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ This was made as a complement to [CloudWatch Exporter](https://github.com/promet
 
 ## Included metadata & metrics
 
-| Service | Metric                    | Description                                        |
-|---------|---------------------------|----------------------------------------------------|
-| RDS     | allocatedstorage          | The amount of allocated storage in GB              |
-| RDS     | dbinstanceclass           | The DB instance class (type)                       |
-| RDS     | dbinstancestatus          | The instance status                                |
-| RDS     | engineversion             | The DB engine type and version                     |
-| RDS     | pendingmaintenanceactions | The pending maintenance actions for a RDS instance |
+| Service | Metric                    | Description                                         |
+|---------|---------------------------|-----------------------------------------------------|
+| RDS     | allocatedstorage          | The amount of allocated storage in GB               |
+| RDS     | dbinstanceclass           | The DB instance class (type)                        |
+| RDS     | dbinstancestatus          | The instance status                                 |
+| RDS     | engineversion             | The DB engine type and version                      |
+| RDS     | pendingmaintenanceactions | The pending maintenance actions for a RDS instance  |
+| RDS     | logs_amount               | The amount of log files present in the RDS Instance |
+| RDS     | logsstorage_size_bytes    | The amount of storage used by the log files nstance |
 
 
 ## Running this software
@@ -47,6 +49,12 @@ Then:
 ## Configuration
 
 AWS credentials can be passed as environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. AWS region must be passed via `AWS_REGION`.
+
+RDS Logs metrics are requested in parallel to improve the scrappping time. Also, metrics are cached to prevent AWS api rate limits. Parameters to
+tweak this behavior.
+
+- `LOGS_METRICS_WORKERS`: Number of workers to request log metrics in parallel (default=10)
+- `LOGS_METRICS_TTL`: Cache TTL for rds logs related metrics (default=300)
 
 To view all available command-line flags, run `./aws-resource-exporter -h`.
 

--- a/env.go
+++ b/env.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"strconv"
+)
+
+func GetEnvIntValue(envname string) (*int, error) {
+	if value, ok := os.LookupEnv(envname); ok {
+		int64val, err := strconv.ParseInt(value, 10, 0)
+		if err != nil {
+			return nil, err
+		} else {
+			intval := int(int64val)
+			return &intval, nil
+		}
+	} else {
+		return nil, nil
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type MetricProxyItem struct {
+	value        interface{}
+	ttl          int
+	creationTime time.Time
+}
+
+type MetricProxy struct {
+	metrics map[string]*MetricProxyItem
+	mutex   sync.Mutex
+}
+
+func NewMetricProxy() *MetricProxy {
+	mp := &MetricProxy{}
+	mp.metrics = make(map[string]*MetricProxyItem)
+	return mp
+}
+
+func (mp *MetricProxy) GetMetricById(id string) (*MetricProxyItem, error) {
+	if m, ok := mp.metrics[id]; ok {
+		if time.Since(m.creationTime).Seconds() > float64(m.ttl) {
+			return nil, errors.New("metric ttl has expired")
+		}
+		return m, nil
+	} else {
+		return nil, errors.New("metric not found")
+	}
+}
+
+func (mp *MetricProxy) StoreMetricById(id string, value interface{}, ttl int) {
+	mp.mutex.Lock()
+	mp.metrics[id] = &MetricProxyItem{
+		value:        value,
+		creationTime: time.Now(),
+		ttl:          ttl,
+	}
+	mp.mutex.Unlock()
+}

--- a/rds.go
+++ b/rds.go
@@ -225,7 +225,7 @@ func getLogfilesMetrics(svc *rds.RDS, instanceId string, e *RDSExporter) *RDSLog
 	}
 
 	for {
-		//exporterMetrics.IncrementRequests()
+		exporterMetrics.IncrementRequests()
 		result, err := svc.DescribeDBLogFiles(input)
 		if err != nil {
 			level.Error(e.logger).Log("msg", "Call to DescribeDBLogFiles failed", "region", *e.sess.Config.Region, "instance", &instanceId, "err", err)
@@ -428,7 +428,6 @@ func (e *RDSExporter) Collect(ch chan<- prometheus.Metric) {
 					"instance", instanceId,
 					"err", err,
 				)
-				exporterMetrics.IncrementRequests()
 				v = getLogfilesMetrics(svc, instanceId, e)
 				metricsProxy.StoreMetricById(instaceLogFilesId, v, 300)
 			} else {

--- a/rds.go
+++ b/rds.go
@@ -18,12 +18,12 @@ import (
 // To get the log metrics an api call for each instance is needed
 // Since this cause rate limit problems to the AWS api, these metrics
 // are cached for this amount of time before requesting them again
-var RDS_LOGS_METRICS_TTL = "RDS_LOGS_METRICS_TTL"
+var RDS_LOGS_METRICS_TTL = "LOGS_METRICS_TTL"
 var RDS_LOGS_METRICS_TTL_DEFAULT = 300
 
 // RDS log metrics are requested in parallel with a workerPool.
 // this variable sets the number of workers
-var RDS_LOGS_METRICS_WORKERS = "RDS_LOGS_METRICS_WORKERS"
+var RDS_LOGS_METRICS_WORKERS = "LOGS_METRICS_WORKERS"
 var RDS_LOGS_METRICS_WORKERS_DEFAULT = 10
 
 // Struct to store RDS Instances log files data
@@ -241,7 +241,7 @@ func NewRDSExporter(sess *session.Session, logger log.Logger) *RDSExporter {
 		workers = &RDS_LOGS_METRICS_WORKERS_DEFAULT
 		level.Info(logger).Log("msg", fmt.Sprintf("Using default value for number Workers: %d", RDS_LOGS_METRICS_WORKERS_DEFAULT))
 	} else {
-		level.Info(logger).Log("msg", fmt.Sprintf("Using Env value for number of Workers: %d", workers))
+		level.Info(logger).Log("msg", fmt.Sprintf("Using Env value for number of Workers: %d", *workers))
 	}
 
 	logMetricsTTL, _ := GetEnvIntValue(RDS_LOGS_METRICS_TTL)
@@ -249,7 +249,7 @@ func NewRDSExporter(sess *session.Session, logger log.Logger) *RDSExporter {
 		logMetricsTTL = &RDS_LOGS_METRICS_TTL_DEFAULT
 		level.Info(logger).Log("msg", fmt.Sprintf("Using default value for logs metrics TTL: %d", RDS_LOGS_METRICS_TTL_DEFAULT))
 	} else {
-		level.Info(logger).Log("msg", fmt.Sprintf("Using Env value for logs metrics TTL: %d", logMetricsTTL))
+		level.Info(logger).Log("msg", fmt.Sprintf("Using Env value for logs metrics TTL: %d", *logMetricsTTL))
 	}
 
 	return &RDSExporter{


### PR DESCRIPTION
## Overview 

- Gather the amount of storage used by the log files and the number of logs of an RDS instance 
- Added a proxy class to act as a cache to prevent hammering the AWS API. Log file metrics are cached with a 300s TTL. 
- Log file metrics are requested in parallel with go routines. 

## Notes

When all the log file metrics are requested, the scraping time might be higher than 10s. I recommend setting the scrape timeout to 45s.

