### PR TITLE
Implement Transit gateway metrics and ec2 exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This was made as a complement to [CloudWatch Exporter](https://github.com/promet
 | VPC     | routetablespervpc           | Quota and usage of routetables per VPC              |
 | VPC     | routesperroutetable         | Quota and usage of the routes per routetable        |
 | VPC     | ipv4blockspervpc            | Quota and usage of ipv4 blocks per VPC              |
+| EC2     | transitgatewaysperregion    | Quota and usage of transitgateways per region       |
 | Route53 | recordsperhostedzone        | Quota and usage of resource records per Hosted Zone |
 
 
@@ -71,7 +72,13 @@ vpc:
   regions:
     - "us-east-1"
     - "eu-central-1"
-    - "eu-central-2"
+  timeout: 30s
+ec2:
+  enabled: true
+  regions:
+    - "us-east-1"
+    - "eu-central-1"
+    - "us-west-1"
   timeout: 30s
 route53:
   enabled: true

--- a/aws-resource-exporter-config.yaml
+++ b/aws-resource-exporter-config.yaml
@@ -1,16 +1,16 @@
 rds:
-  enabled: false
+  enabled: true
   regions:
     - "us-east-1"
 vpc:
-  enabled: false
+  enabled: true
   regions:
     - "us-east-1"
     - "eu-central-1"
     - "eu-central-2"
   timeout: 30s
 route53:
-  enabled: false
+  enabled: true
   region: "us-east-1"
   timeout: 60s
 ec2:

--- a/aws-resource-exporter-config.yaml
+++ b/aws-resource-exporter-config.yaml
@@ -1,15 +1,22 @@
 rds:
-  enabled: true
+  enabled: false
   regions:
     - "us-east-1"
 vpc:
-  enabled: true
+  enabled: false
   regions:
     - "us-east-1"
     - "eu-central-1"
     - "eu-central-2"
   timeout: 30s
 route53:
-  enabled: true
+  enabled: false
   region: "us-east-1"
   timeout: 60s
+ec2:
+  enabled: true
+  regions:
+    - "us-east-1"
+    - "eu-central-1"
+    - "us-west-1"
+  timeout: 30s

--- a/aws-resource-exporter-config.yaml
+++ b/aws-resource-exporter-config.yaml
@@ -7,7 +7,6 @@ vpc:
   regions:
     - "us-east-1"
     - "eu-central-1"
-    - "eu-central-2"
   timeout: 30s
 route53:
   enabled: true

--- a/ec2.go
+++ b/ec2.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	transitGatewayPerAccountQuotaCode string = "L-A2478D36"
+	ec2ServiceCode                    string = "ec2"
+)
+
+var TransitGatewaysQuota *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgateways_quota"), "Quota for maximum number of Transitgateways in this account", []string{"aws_region"}, nil)
+var TransitGatewaysUsage *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgateways_usage"), "Number of Tranitgatewyas in the AWS Account", []string{"aws_region"}, nil)
+
+type EC2Exporter struct {
+	sessions []*session.Session
+
+	logger  log.Logger
+	timeout time.Duration
+}
+
+func NewEC2Exporter(sessions []*session.Session, logger log.Logger, timeout time.Duration) *EC2Exporter {
+
+	level.Info(logger).Log("msg", "Initializing EC2 exporter")
+	return &EC2Exporter{
+		sessions: sessions,
+
+		logger:  logger,
+		timeout: timeout,
+	}
+}
+
+func (e *EC2Exporter) Collect(ch chan<- prometheus.Metric) {
+	//ctx := context.TODO()
+	ctx, ctxCancel := context.WithTimeout(context.Background(), e.timeout)
+	defer ctxCancel()
+	wg := &sync.WaitGroup{}
+	wg.Add(len(e.sessions))
+
+	for _, sess := range e.sessions {
+		go collectInRegion(sess, e.logger, wg, ch, ctx)
+	}
+	wg.Wait()
+}
+
+func collectInRegion(sess *session.Session, logger log.Logger, wg *sync.WaitGroup, ch chan<- prometheus.Metric, ctx context.Context) {
+	defer wg.Done()
+	ec2Svc := ec2.New(sess)
+	serviceQuotaSvc := servicequotas.New(sess)
+
+	quota, err := getQuotaValueWithContext(serviceQuotaSvc, ec2ServiceCode, transitGatewayPerAccountQuotaCode, ctx)
+	if err != nil {
+		level.Error(logger).Log("msg", "Could not retrieve Transit Gateway quota", "error", err.Error())
+		exporterMetrics.IncrementErrors()
+		return
+	}
+
+	gateways, err := getAllTransitGatewaysWithContext(ec2Svc, ctx)
+	if err != nil {
+		level.Error(logger).Log("msg", "Could not retrieve Transit Gateway quota", "error", err.Error())
+		exporterMetrics.IncrementErrors()
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(TransitGatewaysUsage, prometheus.GaugeValue, float64(len(gateways)), *sess.Config.Region)
+	ch <- prometheus.MustNewConstMetric(TransitGatewaysQuota, prometheus.GaugeValue, quota, *sess.Config.Region)
+
+}
+
+func (e *EC2Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- TransitGatewaysQuota
+	ch <- TransitGatewaysUsage
+}
+
+func getAllTransitGatewaysWithContext(client *ec2.EC2, ctx context.Context) ([]*ec2.TransitGateway, error) {
+	results := []*ec2.TransitGateway{}
+	describeGatewaysInput := &ec2.DescribeTransitGatewaysInput{
+		DryRun:     aws.Bool(false),
+		MaxResults: aws.Int64(1000),
+	}
+
+	describeGatewaysOutput, err := client.DescribeTransitGatewaysWithContext(context.TODO(), describeGatewaysInput)
+
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, describeGatewaysOutput.TransitGateways...)
+
+	for describeGatewaysOutput.NextToken != nil {
+		describeGatewaysInput.SetNextToken(*describeGatewaysOutput.NextToken)
+		describeGatewaysOutput, err := client.DescribeTransitGatewaysWithContext(ctx, describeGatewaysInput)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, describeGatewaysOutput.TransitGateways...)
+	}
+
+	return results, nil
+}
+
+func getQuotaValueWithContext(client *servicequotas.ServiceQuotas, serviceCode string, quotaCode string, ctx context.Context) (float64, error) {
+	sqOutput, err := client.GetServiceQuotaWithContext(ctx, &servicequotas.GetServiceQuotaInput{
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	return *sqOutput.Quota.Value, nil
+}

--- a/ec2.go
+++ b/ec2.go
@@ -41,7 +41,6 @@ func NewEC2Exporter(sessions []*session.Session, logger log.Logger, timeout time
 }
 
 func (e *EC2Exporter) Collect(ch chan<- prometheus.Metric) {
-	//ctx := context.TODO()
 	ctx, ctxCancel := context.WithTimeout(context.Background(), e.timeout)
 	defer ctxCancel()
 	wg := &sync.WaitGroup{}
@@ -89,7 +88,7 @@ func getAllTransitGatewaysWithContext(client *ec2.EC2, ctx context.Context) ([]*
 		MaxResults: aws.Int64(1000),
 	}
 
-	describeGatewaysOutput, err := client.DescribeTransitGatewaysWithContext(context.TODO(), describeGatewaysInput)
+	describeGatewaysOutput, err := client.DescribeTransitGatewaysWithContext(ctx, describeGatewaysInput)
 
 	if err != nil {
 		return nil, err

--- a/ec2.go
+++ b/ec2.go
@@ -19,8 +19,8 @@ const (
 	ec2ServiceCode                    string = "ec2"
 )
 
-var TransitGatewaysQuota *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgateways_quota"), "Quota for maximum number of Transitgateways in this account", []string{"aws_region"}, nil)
-var TransitGatewaysUsage *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgateways_usage"), "Number of Tranitgatewyas in the AWS Account", []string{"aws_region"}, nil)
+var TransitGatewaysQuota *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgatewaysperregion_quota"), "Quota for maximum number of Transitgateways in this account", []string{"aws_region"}, nil)
+var TransitGatewaysUsage *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgatewaysperregion_usage"), "Number of Tranitgatewyas in the AWS Account", []string{"aws_region"}, nil)
 
 type EC2Exporter struct {
 	sessions []*session.Session

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 		}
 		collectors = append(collectors, NewRDSExporter(rdsSessions, logger))
 	}
+	level.Info(logger).Log("msg", "Will EC2 metrics be gathered?", "ec2-enabled", config.EC2Config.Enabled)
 	var ec2Sessions []*session.Session
 	if config.EC2Config.Enabled {
 		for _, region := range config.EC2Config.Regions {


### PR DESCRIPTION
This PR adds the following two metrics:
```
ec2_transitgateways_quota
ec2_transitgateways_usage
```
As well as a new ec2 exporter. The configuration of the EC2 Exporter is exactly the same as with the VPC Exporter.