### PR TITLE
Add awsAccountId as a label to privatelink metrics

### DIFF
--- a/ec2.go
+++ b/ec2.go
@@ -19,21 +19,28 @@ const (
 	ec2ServiceCode                    string = "ec2"
 )
 
-var TransitGatewaysQuota *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgatewaysperregion_quota"), "Quota for maximum number of Transitgateways in this account", []string{"aws_region"}, nil)
-var TransitGatewaysUsage *prometheus.Desc = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgatewaysperregion_usage"), "Number of Tranitgatewyas in the AWS Account", []string{"aws_region"}, nil)
+var TransitGatewaysQuota *prometheus.Desc
+var TransitGatewaysUsage *prometheus.Desc
 
 type EC2Exporter struct {
-	sessions []*session.Session
+	awsAccountId string
+	sessions     []*session.Session
 
 	logger  log.Logger
 	timeout time.Duration
 }
 
-func NewEC2Exporter(sessions []*session.Session, logger log.Logger, timeout time.Duration) *EC2Exporter {
+func NewEC2Exporter(sessions []*session.Session, logger log.Logger, timeout time.Duration, awsAccountId string) *EC2Exporter {
 
 	level.Info(logger).Log("msg", "Initializing EC2 exporter")
+	accountIdLabel := map[string]string{"aws_account_id": awsAccountId}
+
+	TransitGatewaysQuota = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgatewaysperregion_quota"), "Quota for maximum number of Transitgateways in this account", []string{"aws_region"}, accountIdLabel)
+	TransitGatewaysUsage = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "ec2_transitgatewaysperregion_usage"), "Number of Tranitgatewyas in the AWS Account", []string{"aws_region"}, accountIdLabel)
+
 	return &EC2Exporter{
-		sessions: sessions,
+		awsAccountId: awsAccountId,
+		sessions:     sessions,
 
 		logger:  logger,
 		timeout: timeout,

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
@@ -88,6 +89,18 @@ func loadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 	return &config, nil
 }
 
+func getAwsAccountNumber(logger log.Logger, creds *credentials.Credentials) (string, error) {
+	config := aws.NewConfig().WithCredentials(creds).WithRegion("us-east-1")
+	sess := session.Must(session.NewSession(config))
+	stsClient := sts.New(sess)
+	identityOutput, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		level.Error(logger).Log("msg", "Could not retrieve caller identity of the aws account", "err", err)
+		return "", err
+	}
+	return *identityOutput.Account, nil
+}
+
 func setupCollectors(logger log.Logger, configFile string, creds *credentials.Credentials) ([]prometheus.Collector, error) {
 	var collectors []prometheus.Collector
 	config, err := loadExporterConfiguration(logger, configFile)
@@ -98,15 +111,19 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 	level.Info(logger).Log("msg", "Configuring rds with regions", "regions", strings.Join(config.RdsConfig.Regions, ","))
 	level.Info(logger).Log("msg", "Configuring ec2 with regions", "regions", strings.Join(config.EC2Config.Regions, ","))
 	level.Info(logger).Log("msg", "Configuring route53 with region", "region", config.Route53Config.Region)
-	var vpcSessions []*session.Session
 	level.Info(logger).Log("msg", "Will VPC metrics be gathered?", "vpc-enabled", config.VpcConfig.Enabled)
+	awsAccountId, err := getAwsAccountNumber(logger, creds)
+	if err != nil {
+		return collectors, err
+	}
+	var vpcSessions []*session.Session
 	if config.VpcConfig.Enabled {
 		for _, region := range config.VpcConfig.Regions {
 			config := aws.NewConfig().WithCredentials(creds).WithRegion(region)
 			sess := session.Must(session.NewSession(config))
 			vpcSessions = append(vpcSessions, sess)
 		}
-		collectors = append(collectors, NewVPCExporter(vpcSessions, logger, config.VpcConfig.Timeout))
+		collectors = append(collectors, NewVPCExporter(vpcSessions, logger, config.VpcConfig.Timeout, awsAccountId))
 	}
 	level.Info(logger).Log("msg", "Will RDS metrics be gathered?", "rds-enabled", config.RdsConfig.Enabled)
 	var rdsSessions []*session.Session
@@ -126,13 +143,13 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 			sess := session.Must(session.NewSession(config))
 			ec2Sessions = append(ec2Sessions, sess)
 		}
-		collectors = append(collectors, NewEC2Exporter(ec2Sessions, logger, config.EC2Config.Timeout))
+		collectors = append(collectors, NewEC2Exporter(ec2Sessions, logger, config.EC2Config.Timeout, awsAccountId))
 	}
 	level.Info(logger).Log("msg", "Will Route53 metrics be gathered?", "route53-enabled", config.Route53Config.Enabled)
 	if config.Route53Config.Enabled {
 		awsConfig := aws.NewConfig().WithCredentials(creds).WithRegion(config.Route53Config.Region)
 		sess := session.Must(session.NewSession(awsConfig))
-		r53Exporter := NewRoute53Exporter(sess, logger, config.Route53Config.Interval, config.Route53Config.Timeout)
+		r53Exporter := NewRoute53Exporter(sess, logger, config.Route53Config.Interval, config.Route53Config.Timeout, awsAccountId)
 		collectors = append(collectors, r53Exporter)
 		go r53Exporter.CollectLoop()
 	}

--- a/route53.go
+++ b/route53.go
@@ -20,6 +20,7 @@ const (
 )
 
 type Route53Exporter struct {
+	awsAccountId              string
 	sess                      *session.Session
 	RecordsPerHostedZoneQuota *prometheus.Desc
 	RecordsPerHostedZoneUsage *prometheus.Desc
@@ -33,15 +34,17 @@ type Route53Exporter struct {
 	timeout       time.Duration
 }
 
-func NewRoute53Exporter(sess *session.Session, logger log.Logger, interval time.Duration, timeout time.Duration) *Route53Exporter {
+func NewRoute53Exporter(sess *session.Session, logger log.Logger, interval time.Duration, timeout time.Duration, awsAccountId string) *Route53Exporter {
 
 	level.Info(logger).Log("msg", "Initializing Route53 exporter")
+	accountIdLabel := map[string]string{"aws_account_id": awsAccountId}
 
 	exporter := &Route53Exporter{
+		awsAccountId:              awsAccountId,
 		sess:                      sess,
-		RecordsPerHostedZoneQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_quota"), "Quota for maximum number of records in a Route53 hosted zone", []string{"hostedzoneid", "hostedzonename"}, nil),
-		RecordsPerHostedZoneUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_total"), "Number of Resource records", []string{"hostedzoneid", "hostedzonename"}, nil),
-		LastUpdateTime:            prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_last_updated_timestamp_seconds"), "Last time, the route53 metrics were sucessfully updated", []string{}, nil),
+		RecordsPerHostedZoneQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_quota"), "Quota for maximum number of records in a Route53 hosted zone", []string{"hostedzoneid", "hostedzonename"}, accountIdLabel),
+		RecordsPerHostedZoneUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_total"), "Number of Resource records", []string{"hostedzoneid", "hostedzonename"}, accountIdLabel),
+		LastUpdateTime:            prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_last_updated_timestamp_seconds"), "Last time, the route53 metrics were sucessfully updated", []string{}, accountIdLabel),
 		cachedMetrics:             []prometheus.Metric{},
 		metricsMutex:              &sync.Mutex{},
 		logger:                    logger,


### PR DESCRIPTION
This will help in quickly identifying which account requires action, if
an alerts pops up.