### PR TITLE
[OSD-12400] Collect Hosted Zones per Account

### DIFF
--- a/route53.go
+++ b/route53.go
@@ -10,21 +10,26 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
-	maxRetries = 5
+	maxRetries           = 10
+	route53ServiceCode   = "route53"
+	hostedZonesQuotaCode = "L-4EA4796A"
 )
 
 type Route53Exporter struct {
-	sess                      *session.Session
-	RecordsPerHostedZoneQuota *prometheus.Desc
-	RecordsPerHostedZoneUsage *prometheus.Desc
-	LastUpdateTime            *prometheus.Desc
-	Cancel                    context.CancelFunc
+	sess                       *session.Session
+	RecordsPerHostedZoneQuota  *prometheus.Desc
+	RecordsPerHostedZoneUsage  *prometheus.Desc
+	HostedZonesPerAccountQuota *prometheus.Desc
+	HostedZonesPerAccountUsage *prometheus.Desc
+	LastUpdateTime             *prometheus.Desc
+	Cancel                     context.CancelFunc
 
 	cachedMetrics []prometheus.Metric
 	metricsMutex  *sync.Mutex
@@ -38,21 +43,85 @@ func NewRoute53Exporter(sess *session.Session, logger log.Logger, interval time.
 	level.Info(logger).Log("msg", "Initializing Route53 exporter")
 
 	exporter := &Route53Exporter{
-		sess:                      sess,
-		RecordsPerHostedZoneQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_quota"), "Quota for maximum number of records in a Route53 hosted zone", []string{"hostedzoneid", "hostedzonename"}, nil),
-		RecordsPerHostedZoneUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_total"), "Number of Resource records", []string{"hostedzoneid", "hostedzonename"}, nil),
-		LastUpdateTime:            prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_last_updated_timestamp_seconds"), "Last time, the route53 metrics were sucessfully updated", []string{}, nil),
-		cachedMetrics:             []prometheus.Metric{},
-		metricsMutex:              &sync.Mutex{},
-		logger:                    logger,
-		interval:                  interval,
-		timeout:                   timeout,
+		sess:                       sess,
+		RecordsPerHostedZoneQuota:  prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_quota"), "Quota for maximum number of records in a Route53 hosted zone", []string{"hostedzoneid", "hostedzonename"}, nil),
+		RecordsPerHostedZoneUsage:  prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_recordsperhostedzone_total"), "Number of Resource records", []string{"hostedzoneid", "hostedzonename"}, nil),
+		HostedZonesPerAccountQuota: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_hostedzonesperaccount_quota"), "Quota for maximum number of Route53 hosted zones in an account", []string{}, nil),
+		HostedZonesPerAccountUsage: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_hostedzonesperaccount_total"), "Number of Resource records", []string{}, nil),
+		LastUpdateTime:             prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "route53_last_updated_timestamp_seconds"), "Last time, the route53 metrics were sucessfully updated", []string{}, nil),
+		cachedMetrics:              []prometheus.Metric{},
+		metricsMutex:               &sync.Mutex{},
+		logger:                     logger,
+		interval:                   interval,
+		timeout:                    timeout,
 	}
 	return exporter
 }
 
+func (e *Route53Exporter) getRecordsPerHostedZoneMetrics(client *route53.Route53, hostedZones []*route53.HostedZone, ctx context.Context) ([]prometheus.Metric, []error) {
+	metricsChan := make(chan prometheus.Metric, len(hostedZones)*2)
+	errChan := make(chan error, len(hostedZones))
+	result := []prometheus.Metric{}
+	errs := []error{}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(hostedZones))
+	sem := make(chan int, 10)
+	defer close(sem)
+	for i, hostedZone := range hostedZones {
+
+		sem <- 1
+		go func(i int, hostedZone *route53.HostedZone) {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+			hostedZoneLimitOut, err := GetHostedZoneLimitWithBackoff(client, ctx, hostedZone.Id, maxRetries)
+
+			if err != nil {
+				errChan <- fmt.Errorf("Could not get Limits for hosted zone with ID '%s' and name '%s'. Error was: %s", *hostedZone.Id, *hostedZone.Name, err.Error())
+				level.Info(e.logger).Log("msg", "ERROR")
+				exporterMetrics.IncrementErrors()
+				return
+			}
+			level.Info(e.logger).Log("msg", fmt.Sprintf("Currently at hosted zone: %d / %d", i, len(hostedZones)))
+			metricsChan <- prometheus.MustNewConstMetric(e.RecordsPerHostedZoneQuota, prometheus.GaugeValue, float64(*hostedZoneLimitOut.Limit.Value), *hostedZone.Id, *hostedZone.Name)
+			metricsChan <- prometheus.MustNewConstMetric(e.RecordsPerHostedZoneUsage, prometheus.GaugeValue, float64(*hostedZoneLimitOut.Count), *hostedZone.Id, *hostedZone.Name)
+
+		}(i, hostedZone)
+	}
+	wg.Wait()
+	close(errChan)
+	close(metricsChan)
+
+	for metric := range metricsChan {
+		result = append(result, metric)
+	}
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	return result, errs
+}
+
+func (e *Route53Exporter) getHostedZonesPerAccountMetrics(client *servicequotas.ServiceQuotas, hostedZones []*route53.HostedZone, ctx context.Context) ([]prometheus.Metric, error) {
+	result := []prometheus.Metric{}
+	quota, err := getQuotaValueWithContext(client, route53ServiceCode, hostedZonesQuotaCode, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result = append(result,
+		prometheus.MustNewConstMetric(e.HostedZonesPerAccountQuota, prometheus.GaugeValue, quota),
+		prometheus.MustNewConstMetric(e.HostedZonesPerAccountUsage, prometheus.GaugeValue, float64(len(hostedZones))),
+	)
+	return result, nil
+}
+
+// CollectLoop runs indefinitely to collect the route53 metrics in a cache. Metrics are only written into the cache once all have been collected to ensure that we don't have a partial collect.
 func (e *Route53Exporter) CollectLoop() {
 	route53Svc := route53.New(e.sess)
+	serviceQuotaSvc := servicequotas.New(e.sess)
 
 	for {
 		ctx, ctxCancelFunc := context.WithTimeout(context.Background(), e.timeout)
@@ -60,33 +129,31 @@ func (e *Route53Exporter) CollectLoop() {
 		level.Info(e.logger).Log("msg", "Updating Route53 metrics...")
 
 		hostedZones, err := getAllHostedZones(route53Svc, ctx)
+
 		level.Info(e.logger).Log("msg", "Got all zones")
 		if err != nil {
 			level.Error(e.logger).Log("msg", "Could not retrieve the list of hosted zones", "error", err.Error())
 			exporterMetrics.IncrementErrors()
 		}
-		tmpMetrics := []prometheus.Metric{}
 
-		for i, hostedZone := range hostedZones {
-			hostedZoneLimitOut, err := GetHostedZoneLimitWithBackoff(route53Svc, ctx, hostedZone.Id, maxRetries)
+		allMetrics := []prometheus.Metric{}
+		hostedZonesPerAccountMetrics, err := e.getHostedZonesPerAccountMetrics(serviceQuotaSvc, hostedZones, ctx)
+		allMetrics = append(allMetrics, hostedZonesPerAccountMetrics...)
 
-			if err != nil {
-				level.Error(e.logger).Log("msg", "Could not get Quota for hosted zone", "hostedZoneId", hostedZone.Id, "hostedZoneName", hostedZone.Name, "error", err.Error())
-				exporterMetrics.IncrementErrors()
-				continue
-			}
-			level.Info(e.logger).Log("msg", "R53 Gathered", "num", i, "total", len(hostedZones))
-			tmpMetrics = append(tmpMetrics,
-				prometheus.MustNewConstMetric(e.RecordsPerHostedZoneQuota, prometheus.GaugeValue, float64(*hostedZoneLimitOut.Limit.Value), *hostedZone.Id, *hostedZone.Name),
-				prometheus.MustNewConstMetric(e.RecordsPerHostedZoneUsage, prometheus.GaugeValue, float64(*hostedZoneLimitOut.Count), *hostedZone.Id, *hostedZone.Name),
-			)
+		recordsPerHostedZoneMetrics, errs := e.getRecordsPerHostedZoneMetrics(route53Svc, hostedZones, ctx)
+		for _, err = range errs {
+			level.Error(e.logger).Log("msg", "Could not get limits for hosted zone", "error", err.Error())
+			exporterMetrics.IncrementErrors()
 		}
+
+		allMetrics = append(allMetrics, recordsPerHostedZoneMetrics...)
+
 		e.metricsMutex.Lock()
-		e.cachedMetrics = append(tmpMetrics, prometheus.MustNewConstMetric(e.LastUpdateTime, prometheus.GaugeValue, float64(time.Now().Unix())))
+		e.cachedMetrics = append(allMetrics, prometheus.MustNewConstMetric(e.LastUpdateTime, prometheus.GaugeValue, float64(time.Now().Unix())))
 		e.metricsMutex.Unlock()
 		level.Info(e.logger).Log("msg", "Route53 metrics Updated")
 
-		ctxCancelFunc()
+		ctxCancelFunc() // should never do anything as we don't run stuff in the background
 
 		time.Sleep(e.interval)
 	}
@@ -139,7 +206,7 @@ func ListHostedZonesWithBackoff(client *route53.Route53, ctx context.Context, in
 			return listHostedZonesOut, err
 		}
 		backOffSeconds := math.Pow(2, float64(i-1))
-		fmt.Printf("Backing off for %f seconds", backOffSeconds)
+		fmt.Printf("Backing off for %f.1 seconds\n", backOffSeconds)
 		time.Sleep(time.Duration(backOffSeconds) * time.Second)
 	}
 	return nil, err


### PR DESCRIPTION
This PR implements the last part of [OSD-12400](https://issues.redhat.com/browse/OSD-12400), collecting the number of hosted zones per account. 
It also parallelizes the collection of the `RecordSetsPerHostedZone`-metric, so it doesn't take forever.

**Testing**
first, make sure you're actually logged in to an aws account. Then run the following to disable the unneeded exporters
```
$ cat << EOF > ./aws-resource-exporter-config.yaml
rds:
  enabled: false
  regions:
    - "us-east-1"
vpc:
  enabled: false
  regions:
    - "us-east-1"
    - "eu-central-1"
  timeout: 30s
route53:
  enabled: true
  region: "us-east-1"
  timeout: 300s
  interval: 300s
ec2:
  enabled: false
  regions:
    - "us-west-1"
  timeout: 30s
EOF

# then, build & run the exporter:
$ go build
$ ./aws-resource-exporter
```

Wait until you see the message:
```
level=info ts=2022-08-31T13:49:06.561Z caller=route53.go:154 msg="Route53 metrics Updated"
```
on the console. This means, that all the r53 metrics have been collected and can now be retrieved from the cache.
In a separate shell window, run the following:
```
$ curl localhost:9115/metrics | grep "hostedzonesperaccount"
```
Make sure this prints out the newly implemented metrics, for example:
```
# HELP aws_resources_exporter_route53_hostedzonesperaccount_quota Quota for maximum number of Route53 hosted zones in an account
# TYPE aws_resources_exporter_route53_hostedzonesperaccount_quota gauge
aws_resources_exporter_route53_hostedzonesperaccount_quota 2000
# HELP aws_resources_exporter_route53_hostedzonesperaccount_total Number of Resource records
# TYPE aws_resources_exporter_route53_hostedzonesperaccount_total gauge
aws_resources_exporter_route53_hostedzonesperaccount_total 487

```