### PR TITLE
use default credential management

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/promlog"
@@ -129,7 +128,7 @@ func loadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 	return &config, nil
 }
 
-func setupCollectors(logger log.Logger, configFile string, creds *credentials.Credentials) ([]prometheus.Collector, error) {
+func setupCollectors(logger log.Logger, configFile string) ([]prometheus.Collector, error) {
 	var collectors []prometheus.Collector
 	config, err := loadExporterConfiguration(logger, configFile)
 	if err != nil {
@@ -143,7 +142,7 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 	level.Info(logger).Log("msg", "Will VPC metrics be gathered?", "vpc-enabled", config.VpcConfig.Enabled)
 	if config.VpcConfig.Enabled {
 		for _, region := range config.VpcConfig.Regions {
-			config := aws.NewConfig().WithCredentials(creds).WithRegion(region)
+			config := aws.NewConfig().WithRegion(region)
 			sess := session.Must(session.NewSession(config))
 			vpcSessions = append(vpcSessions, sess)
 		}
@@ -155,7 +154,7 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 	var rdsSessions []*session.Session
 	if config.RdsConfig.Enabled {
 		for _, region := range config.RdsConfig.Regions {
-			config := aws.NewConfig().WithCredentials(creds).WithRegion(region)
+			config := aws.NewConfig().WithRegion(region)
 			sess := session.Must(session.NewSession(config))
 			rdsSessions = append(rdsSessions, sess)
 		}
@@ -167,7 +166,7 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 	var ec2Sessions []*session.Session
 	if config.EC2Config.Enabled {
 		for _, region := range config.EC2Config.Regions {
-			config := aws.NewConfig().WithCredentials(creds).WithRegion(region)
+			config := aws.NewConfig().WithRegion(region)
 			sess := session.Must(session.NewSession(config))
 			ec2Sessions = append(ec2Sessions, sess)
 		}
@@ -177,7 +176,7 @@ func setupCollectors(logger log.Logger, configFile string, creds *credentials.Cr
 	}
 	level.Info(logger).Log("msg", "Will Route53 metrics be gathered?", "route53-enabled", config.Route53Config.Enabled)
 	if config.Route53Config.Enabled {
-		awsConfig := aws.NewConfig().WithCredentials(creds).WithRegion(config.Route53Config.Region)
+		awsConfig := aws.NewConfig().WithRegion(config.Route53Config.Region)
 		sess := session.Must(session.NewSession(awsConfig))
 		r53Exporter := NewRoute53Exporter(sess, logger, config.Route53Config)
 		collectors = append(collectors, r53Exporter)
@@ -198,12 +197,6 @@ func run() int {
 	level.Info(logger).Log("msg", "Starting"+namespace, "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
 
-	creds := credentials.NewEnvCredentials()
-	if _, err := creds.Get(); err != nil {
-		level.Error(logger).Log("msg", "Could not get AWS credentials from env variables", "err", err)
-		return 1
-	}
-
 	exporterMetrics = NewExporterMetrics()
 	var configFile string
 	if path := os.Getenv("AWS_RESOURCE_EXPORTER_CONFIG_FILE"); path != "" {
@@ -211,7 +204,7 @@ func run() int {
 	} else {
 		configFile = CONFIG_FILE_PATH
 	}
-	cs, err := setupCollectors(logger, configFile, creds)
+	cs, err := setupCollectors(logger, configFile)
 	if err != nil {
 		level.Error(logger).Log("msg", "Could not load configuration file", "err", err)
 		return 1


### PR DESCRIPTION
Instead of using static credentials only, I propose to use the [default credentials management](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) which includes static ones, but also assume roles and service accounts for Kubernetes usage.

This PR is a split from https://github.com/app-sre/aws-resource-exporter/pull/62