### PR TITLE
Add tests to rds.go 

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/app-sre/aws-resource-exporter/pkg"
+	"github.com/app-sre/aws-resource-exporter/pkg/awsclient"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -124,7 +125,7 @@ func run() int {
 	level.Info(logger).Log("msg", "Starting"+namespace, "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
 
-	pkg.AwsExporterMetrics = pkg.NewExporterMetrics()
+	awsclient.AwsExporterMetrics = awsclient.NewExporterMetrics(namespace)
 
 	var configFile string
 	if path := os.Getenv("AWS_RESOURCE_EXPORTER_CONFIG_FILE"); path != "" {
@@ -137,7 +138,7 @@ func run() int {
 		level.Error(logger).Log("msg", "Could not load configuration file", "err", err)
 		return 1
 	}
-	collectors := append(cs, pkg.AwsExporterMetrics)
+	collectors := append(cs, awsclient.AwsExporterMetrics)
 	prometheus.MustRegister(
 		collectors...,
 	)

--- a/pkg/awsclient/awsclient.go
+++ b/pkg/awsclient/awsclient.go
@@ -21,11 +21,7 @@ type Client interface {
 	DescribeTransitGatewaysWithContext(ctx aws.Context, input *ec2.DescribeTransitGatewaysInput, opts ...request.Option) (*ec2.DescribeTransitGatewaysOutput, error)
 
 	// Service Quota
-	GetServiceQuota(*servicequotas.GetServiceQuotaInput) (*servicequotas.GetServiceQuotaOutput, error)
 	GetServiceQuotaWithContext(ctx aws.Context, input *servicequotas.GetServiceQuotaInput, opts ...request.Option) (*servicequotas.GetServiceQuotaOutput, error)
-	RequestServiceQuotaIncrease(*servicequotas.RequestServiceQuotaIncreaseInput) (*servicequotas.RequestServiceQuotaIncreaseOutput, error)
-	ListRequestedServiceQuotaChangeHistory(*servicequotas.ListRequestedServiceQuotaChangeHistoryInput) (*servicequotas.ListRequestedServiceQuotaChangeHistoryOutput, error)
-	ListRequestedServiceQuotaChangeHistoryByQuota(*servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaInput) (*servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaOutput, error)
 }
 
 type awsClient struct {
@@ -37,28 +33,8 @@ func (c *awsClient) DescribeTransitGatewaysWithContext(ctx aws.Context, input *e
 	return c.ec2Client.DescribeTransitGatewaysWithContext(ctx, input, opts...)
 }
 
-func (c *awsClient) DeleteSubnet(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
-	return c.ec2Client.DeleteSubnet(input)
-}
-
-func (c *awsClient) GetServiceQuota(input *servicequotas.GetServiceQuotaInput) (*servicequotas.GetServiceQuotaOutput, error) {
-	return c.serviceQuotasClient.GetServiceQuota(input)
-}
-
 func (c *awsClient) GetServiceQuotaWithContext(ctx aws.Context, input *servicequotas.GetServiceQuotaInput, opts ...request.Option) (*servicequotas.GetServiceQuotaOutput, error) {
 	return c.serviceQuotasClient.GetServiceQuotaWithContext(ctx, input, opts...)
-}
-
-func (c *awsClient) RequestServiceQuotaIncrease(input *servicequotas.RequestServiceQuotaIncreaseInput) (*servicequotas.RequestServiceQuotaIncreaseOutput, error) {
-	return c.serviceQuotasClient.RequestServiceQuotaIncrease(input)
-}
-
-func (c *awsClient) ListRequestedServiceQuotaChangeHistory(input *servicequotas.ListRequestedServiceQuotaChangeHistoryInput) (*servicequotas.ListRequestedServiceQuotaChangeHistoryOutput, error) {
-	return c.serviceQuotasClient.ListRequestedServiceQuotaChangeHistory(input)
-}
-
-func (c *awsClient) ListRequestedServiceQuotaChangeHistoryByQuota(input *servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaInput) (*servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaOutput, error) {
-	return c.serviceQuotasClient.ListRequestedServiceQuotaChangeHistoryByQuota(input)
 }
 
 func NewClientFromSession(sess *session.Session) Client {

--- a/pkg/awsclient/awsclient.go
+++ b/pkg/awsclient/awsclient.go
@@ -68,12 +68,13 @@ func (c *awsClient) DescribeDBLogFilesAll(ctx context.Context, instanceId string
 
 	var logOutPuts []*rds.DescribeDBLogFilesOutput
 	err := c.DescribeDBLogFilesPagesWithContext(ctx, input, func(ddlo *rds.DescribeDBLogFilesOutput, b bool) bool {
-		// AwsExporterMetrics.IncrementRequests()
+		AwsExporterMetrics.IncrementRequests()
 		logOutPuts = append(logOutPuts, ddlo)
 		return true
 	})
 
 	if err != nil {
+		AwsExporterMetrics.IncrementErrors()
 		return nil, err
 	}
 
@@ -85,11 +86,13 @@ func (c *awsClient) DescribePendingMaintenanceActionsAll(ctx context.Context) ([
 
 	var instancesPendMaintActionsData []*rds.ResourcePendingMaintenanceActions
 	err := c.DescribePendingMaintenanceActionsPagesWithContext(ctx, describePendingMaintInput, func(dpm *rds.DescribePendingMaintenanceActionsOutput, b bool) bool {
+		AwsExporterMetrics.IncrementRequests()
 		instancesPendMaintActionsData = append(instancesPendMaintActionsData, dpm.PendingMaintenanceActions...)
 		return true
 	})
 
 	if err != nil {
+		AwsExporterMetrics.IncrementErrors()
 		return nil, err
 	}
 
@@ -101,10 +104,12 @@ func (c *awsClient) DescribeDBInstancesAll(ctx context.Context) ([]*rds.DBInstan
 
 	var instances []*rds.DBInstance
 	err := c.DescribeDBInstancesPagesWithContext(ctx, input, func(ddo *rds.DescribeDBInstancesOutput, b bool) bool {
+		AwsExporterMetrics.IncrementRequests()
 		instances = append(instances, ddo.DBInstances...)
 		return true
 	})
 	if err != nil {
+		AwsExporterMetrics.IncrementErrors()
 		return nil, err
 	}
 	return instances, nil

--- a/pkg/awsclient/exporter.go
+++ b/pkg/awsclient/exporter.go
@@ -1,4 +1,4 @@
-package pkg
+package awsclient
 
 import (
 	"sync"
@@ -23,7 +23,7 @@ type ExporterMetrics struct {
 }
 
 // NewExporterMetrics creates a new exporter metrics instance
-func NewExporterMetrics() *ExporterMetrics {
+func NewExporterMetrics(namespace string) *ExporterMetrics {
 	return &ExporterMetrics{
 		APIRequests: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "apirequests"),

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -57,21 +57,6 @@ func (mr *MockClientMockRecorder) DescribeTransitGatewaysWithContext(ctx, input 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewaysWithContext", reflect.TypeOf((*MockClient)(nil).DescribeTransitGatewaysWithContext), varargs...)
 }
 
-// GetServiceQuota mocks base method.
-func (m *MockClient) GetServiceQuota(arg0 *servicequotas.GetServiceQuotaInput) (*servicequotas.GetServiceQuotaOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceQuota", arg0)
-	ret0, _ := ret[0].(*servicequotas.GetServiceQuotaOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetServiceQuota indicates an expected call of GetServiceQuota.
-func (mr *MockClientMockRecorder) GetServiceQuota(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceQuota", reflect.TypeOf((*MockClient)(nil).GetServiceQuota), arg0)
-}
-
 // GetServiceQuotaWithContext mocks base method.
 func (m *MockClient) GetServiceQuotaWithContext(ctx aws.Context, input *servicequotas.GetServiceQuotaInput, opts ...request.Option) (*servicequotas.GetServiceQuotaOutput, error) {
 	m.ctrl.T.Helper()
@@ -90,49 +75,4 @@ func (mr *MockClientMockRecorder) GetServiceQuotaWithContext(ctx, input interfac
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, input}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceQuotaWithContext", reflect.TypeOf((*MockClient)(nil).GetServiceQuotaWithContext), varargs...)
-}
-
-// ListRequestedServiceQuotaChangeHistory mocks base method.
-func (m *MockClient) ListRequestedServiceQuotaChangeHistory(arg0 *servicequotas.ListRequestedServiceQuotaChangeHistoryInput) (*servicequotas.ListRequestedServiceQuotaChangeHistoryOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRequestedServiceQuotaChangeHistory", arg0)
-	ret0, _ := ret[0].(*servicequotas.ListRequestedServiceQuotaChangeHistoryOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRequestedServiceQuotaChangeHistory indicates an expected call of ListRequestedServiceQuotaChangeHistory.
-func (mr *MockClientMockRecorder) ListRequestedServiceQuotaChangeHistory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRequestedServiceQuotaChangeHistory", reflect.TypeOf((*MockClient)(nil).ListRequestedServiceQuotaChangeHistory), arg0)
-}
-
-// ListRequestedServiceQuotaChangeHistoryByQuota mocks base method.
-func (m *MockClient) ListRequestedServiceQuotaChangeHistoryByQuota(arg0 *servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaInput) (*servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRequestedServiceQuotaChangeHistoryByQuota", arg0)
-	ret0, _ := ret[0].(*servicequotas.ListRequestedServiceQuotaChangeHistoryByQuotaOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRequestedServiceQuotaChangeHistoryByQuota indicates an expected call of ListRequestedServiceQuotaChangeHistoryByQuota.
-func (mr *MockClientMockRecorder) ListRequestedServiceQuotaChangeHistoryByQuota(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRequestedServiceQuotaChangeHistoryByQuota", reflect.TypeOf((*MockClient)(nil).ListRequestedServiceQuotaChangeHistoryByQuota), arg0)
-}
-
-// RequestServiceQuotaIncrease mocks base method.
-func (m *MockClient) RequestServiceQuotaIncrease(arg0 *servicequotas.RequestServiceQuotaIncreaseInput) (*servicequotas.RequestServiceQuotaIncreaseOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestServiceQuotaIncrease", arg0)
-	ret0, _ := ret[0].(*servicequotas.RequestServiceQuotaIncreaseOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RequestServiceQuotaIncrease indicates an expected call of RequestServiceQuotaIncrease.
-func (mr *MockClientMockRecorder) RequestServiceQuotaIncrease(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestServiceQuotaIncrease", reflect.TypeOf((*MockClient)(nil).RequestServiceQuotaIncrease), arg0)
 }

--- a/pkg/awsclient/mock/zz_generated.mock_client.go
+++ b/pkg/awsclient/mock/zz_generated.mock_client.go
@@ -5,11 +5,13 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
+	rds "github.com/aws/aws-sdk-go/service/rds"
 	servicequotas "github.com/aws/aws-sdk-go/service/servicequotas"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -35,6 +37,108 @@ func NewMockClient(ctrl *gomock.Controller) *MockClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
+}
+
+// DescribeDBInstancesAll mocks base method.
+func (m *MockClient) DescribeDBInstancesAll(ctx context.Context) ([]*rds.DBInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeDBInstancesAll", ctx)
+	ret0, _ := ret[0].([]*rds.DBInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeDBInstancesAll indicates an expected call of DescribeDBInstancesAll.
+func (mr *MockClientMockRecorder) DescribeDBInstancesAll(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDBInstancesAll", reflect.TypeOf((*MockClient)(nil).DescribeDBInstancesAll), ctx)
+}
+
+// DescribeDBInstancesPagesWithContext mocks base method.
+func (m *MockClient) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, opts ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, input, fn}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeDBInstancesPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeDBInstancesPagesWithContext indicates an expected call of DescribeDBInstancesPagesWithContext.
+func (mr *MockClientMockRecorder) DescribeDBInstancesPagesWithContext(ctx, input, fn interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, input, fn}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDBInstancesPagesWithContext", reflect.TypeOf((*MockClient)(nil).DescribeDBInstancesPagesWithContext), varargs...)
+}
+
+// DescribeDBLogFilesAll mocks base method.
+func (m *MockClient) DescribeDBLogFilesAll(ctx context.Context, instanceId string) ([]*rds.DescribeDBLogFilesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeDBLogFilesAll", ctx, instanceId)
+	ret0, _ := ret[0].([]*rds.DescribeDBLogFilesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeDBLogFilesAll indicates an expected call of DescribeDBLogFilesAll.
+func (mr *MockClientMockRecorder) DescribeDBLogFilesAll(ctx, instanceId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDBLogFilesAll", reflect.TypeOf((*MockClient)(nil).DescribeDBLogFilesAll), ctx, instanceId)
+}
+
+// DescribeDBLogFilesPagesWithContext mocks base method.
+func (m *MockClient) DescribeDBLogFilesPagesWithContext(ctx aws.Context, input *rds.DescribeDBLogFilesInput, fn func(*rds.DescribeDBLogFilesOutput, bool) bool, opts ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, input, fn}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeDBLogFilesPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeDBLogFilesPagesWithContext indicates an expected call of DescribeDBLogFilesPagesWithContext.
+func (mr *MockClientMockRecorder) DescribeDBLogFilesPagesWithContext(ctx, input, fn interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, input, fn}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDBLogFilesPagesWithContext", reflect.TypeOf((*MockClient)(nil).DescribeDBLogFilesPagesWithContext), varargs...)
+}
+
+// DescribePendingMaintenanceActionsAll mocks base method.
+func (m *MockClient) DescribePendingMaintenanceActionsAll(ctx context.Context) ([]*rds.ResourcePendingMaintenanceActions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribePendingMaintenanceActionsAll", ctx)
+	ret0, _ := ret[0].([]*rds.ResourcePendingMaintenanceActions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribePendingMaintenanceActionsAll indicates an expected call of DescribePendingMaintenanceActionsAll.
+func (mr *MockClientMockRecorder) DescribePendingMaintenanceActionsAll(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePendingMaintenanceActionsAll", reflect.TypeOf((*MockClient)(nil).DescribePendingMaintenanceActionsAll), ctx)
+}
+
+// DescribePendingMaintenanceActionsPagesWithContext mocks base method.
+func (m *MockClient) DescribePendingMaintenanceActionsPagesWithContext(ctx aws.Context, input *rds.DescribePendingMaintenanceActionsInput, fn func(*rds.DescribePendingMaintenanceActionsOutput, bool) bool, opts ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, input, fn}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribePendingMaintenanceActionsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribePendingMaintenanceActionsPagesWithContext indicates an expected call of DescribePendingMaintenanceActionsPagesWithContext.
+func (mr *MockClientMockRecorder) DescribePendingMaintenanceActionsPagesWithContext(ctx, input, fn interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, input, fn}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePendingMaintenanceActionsPagesWithContext", reflect.TypeOf((*MockClient)(nil).DescribePendingMaintenanceActionsPagesWithContext), varargs...)
 }
 
 // DescribeTransitGatewaysWithContext mocks base method.

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -13,6 +13,7 @@ import (
 type BaseConfig struct {
 	Enabled  bool           `yaml:"enabled"`
 	Interval *time.Duration `yaml:"interval"`
+	Timeout  *time.Duration `yaml:"timeout"`
 	CacheTTL *time.Duration `yaml:"cache_ttl"`
 }
 
@@ -23,20 +24,17 @@ type RDSConfig struct {
 
 type VPCConfig struct {
 	BaseConfig `yaml:"base,inline"`
-	Timeout    *time.Duration `yaml:"timeout"`
-	Regions    []string       `yaml:"regions"`
+	Regions    []string `yaml:"regions"`
 }
 
 type Route53Config struct {
 	BaseConfig `yaml:"base,inline"`
-	Timeout    *time.Duration `yaml:"timeout"`
-	Region     string         `yaml:"region"` // Use only a single Region for now, as the current metric is global
+	Region     string `yaml:"region"` // Use only a single Region for now, as the current metric is global
 }
 
 type EC2Config struct {
 	BaseConfig `yaml:"base,inline"`
-	Timeout    *time.Duration `yaml:"timeout"`
-	Regions    []string       `yaml:"regions"`
+	Regions    []string `yaml:"regions"`
 }
 
 type Config struct {
@@ -81,6 +79,9 @@ func LoadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 		config.EC2Config.Interval = durationPtr(15 * time.Second)
 	}
 
+	if config.RdsConfig.Timeout == nil {
+		config.RdsConfig.Timeout = durationPtr(10 * time.Second)
+	}
 	if config.VpcConfig.Timeout == nil {
 		config.VpcConfig.Timeout = durationPtr(10 * time.Second)
 	}

--- a/pkg/ec2.go
+++ b/pkg/ec2.go
@@ -82,14 +82,14 @@ func (e *EC2Exporter) collectInRegion(sess *session.Session, logger log.Logger, 
 	quota, err := getQuotaValueWithContext(aws, ec2ServiceCode, transitGatewayPerAccountQuotaCode, ctx)
 	if err != nil {
 		level.Error(logger).Log("msg", "Could not retrieve Transit Gateway quota", "error", err.Error())
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 
 	gateways, err := getAllTransitGatewaysWithContext(aws, ctx)
 	if err != nil {
 		level.Error(logger).Log("msg", "Could not retrieve Transit Gateway quota", "error", err.Error())
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 

--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -348,7 +348,6 @@ func (e *RDSExporter) requestRDSLogMetrics(ctx context.Context, sessionIndex int
 	logOutPuts, err := e.svcs[sessionIndex].DescribeDBLogFilesAll(ctx, instanceId)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeDBLogFiles failed", "region", e.getRegion(sessionIndex), "instance", &instanceId, "err", err)
-		AwsExporterMetrics.IncrementErrors()
 		return nil, err
 	}
 
@@ -525,7 +524,6 @@ func (e *RDSExporter) CollectLoop() {
 			instances, err := e.svcs[i].DescribeDBInstancesAll(ctx)
 			if err != nil {
 				level.Error(e.logger).Log("msg", "Call to DescribeDBInstances failed", "region", *e.sessions[i].Config.Region, "err", err)
-				AwsExporterMetrics.IncrementErrors()
 			}
 
 			wg := sync.WaitGroup{}

--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -1,11 +1,13 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/app-sre/aws-resource-exporter/pkg/awsclient"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/go-kit/kit/log"
@@ -210,22 +212,83 @@ var DBMaxConnections = map[string]map[string]int64{
 	},
 }
 
+var AllocatedStorage *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_allocatedstorage"),
+	"The amount of allocated storage in bytes.",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+var DBInstanceClass *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_dbinstanceclass"),
+	"The DB instance class (type).",
+	[]string{"aws_region", "dbinstance_identifier", "instance_class"},
+	nil,
+)
+var DBInstanceStatus *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_dbinstancestatus"),
+	"The instance status.",
+	[]string{"aws_region", "dbinstance_identifier", "instance_status"},
+	nil,
+)
+var EngineVersion *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_engineversion"),
+	"The DB engine type and version.",
+	[]string{"aws_region", "dbinstance_identifier", "engine", "engine_version"},
+	nil,
+)
+var LatestRestorableTime *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_latestrestorabletime"),
+	"Latest restorable time (UTC date timestamp).",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+var MaxConnections *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_maxconnections"),
+	"The DB's max_connections value",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+var MaxConnectionsMappingError *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_maxconnections_error"),
+	"Indicates no mapping found for instance/parameter group.",
+	[]string{"aws_region", "dbinstance_identifier", "instance_class"},
+	nil,
+)
+var PendingMaintenanceActions *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_pendingmaintenanceactions"),
+	"Pending maintenance actions for a RDS instance. 0 indicates no available maintenance and a separate metric with a value of 1 will be published for every separate action.",
+	[]string{"aws_region", "dbinstance_identifier", "action", "auto_apply_after", "current_apply_date", "description"},
+	nil,
+)
+var PubliclyAccessible *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_publiclyaccessible"),
+	"Indicates if the DB is publicly accessible",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+var StorageEncrypted *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_storageencrypted"),
+	"Indicates if the DB storage is encrypted",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+var LogsStorageSize *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_logsstorage_size_bytes"),
+	"The amount of storage consumed by log files (in bytes)",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+var LogsAmount *prometheus.Desc = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "rds_logs_amount"),
+	"The amount of existent log files",
+	[]string{"aws_region", "dbinstance_identifier"},
+	nil,
+)
+
 // RDSExporter defines an instance of the RDS Exporter
 type RDSExporter struct {
-	sessions                   []*session.Session
-	svcs                       []*rds.RDS
-	AllocatedStorage           *prometheus.Desc
-	DBInstanceClass            *prometheus.Desc
-	DBInstanceStatus           *prometheus.Desc
-	EngineVersion              *prometheus.Desc
-	LatestRestorableTime       *prometheus.Desc
-	MaxConnections             *prometheus.Desc
-	MaxConnectionsMappingError *prometheus.Desc
-	PendingMaintenanceActions  *prometheus.Desc
-	PubliclyAccessible         *prometheus.Desc
-	StorageEncrypted           *prometheus.Desc
-	LogsStorageSize            *prometheus.Desc
-	LogsAmount                 *prometheus.Desc
+	sessions []*session.Session
+	svcs     []awsclient.Client
 
 	workers        int
 	logsMetricsTTL int
@@ -233,6 +296,7 @@ type RDSExporter struct {
 	logger   log.Logger
 	cache    MetricsCache
 	interval time.Duration
+	timeout  time.Duration
 }
 
 // NewRDSExporter creates a new RDSExporter instance
@@ -254,9 +318,9 @@ func NewRDSExporter(sessions []*session.Session, logger log.Logger, config RDSCo
 	} else {
 		level.Info(logger).Log("msg", fmt.Sprintf("Using Env value for logs metrics TTL: %d", *logMetricsTTL))
 	}
-	var rdses []*rds.RDS
+	var rdses []awsclient.Client
 	for _, session := range sessions {
-		rdses = append(rdses, rds.New(session))
+		rdses = append(rdses, awsclient.NewClientFromSession(session))
 	}
 
 	return &RDSExporter{
@@ -264,81 +328,10 @@ func NewRDSExporter(sessions []*session.Session, logger log.Logger, config RDSCo
 		svcs:           rdses,
 		workers:        *workers,
 		logsMetricsTTL: *logMetricsTTL,
-		AllocatedStorage: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_allocatedstorage"),
-			"The amount of allocated storage in bytes.",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		DBInstanceClass: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_dbinstanceclass"),
-			"The DB instance class (type).",
-			[]string{"aws_region", "dbinstance_identifier", "instance_class"},
-			nil,
-		),
-		DBInstanceStatus: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_dbinstancestatus"),
-			"The instance status.",
-			[]string{"aws_region", "dbinstance_identifier", "instance_status"},
-			nil,
-		),
-		EngineVersion: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_engineversion"),
-			"The DB engine type and version.",
-			[]string{"aws_region", "dbinstance_identifier", "engine", "engine_version"},
-			nil,
-		),
-		LatestRestorableTime: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_latestrestorabletime"),
-			"Latest restorable time (UTC date timestamp).",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		MaxConnections: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_maxconnections"),
-			"The DB's max_connections value",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		MaxConnectionsMappingError: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_maxconnections_error"),
-			"Indicates no mapping found for instance/parameter group.",
-			[]string{"aws_region", "dbinstance_identifier", "instance_class"},
-			nil,
-		),
-		PendingMaintenanceActions: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_pendingmaintenanceactions"),
-			"Pending maintenance actions for a RDS instance. 0 indicates no available maintenance and a separate metric with a value of 1 will be published for every separate action.",
-			[]string{"aws_region", "dbinstance_identifier", "action", "auto_apply_after", "current_apply_date", "description"},
-			nil,
-		),
-		PubliclyAccessible: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_publiclyaccessible"),
-			"Indicates if the DB is publicly accessible",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		StorageEncrypted: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_storageencrypted"),
-			"Indicates if the DB storage is encrypted",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		LogsStorageSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_logsstorage_size_bytes"),
-			"The amount of storage consumed by log files (in bytes)",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		LogsAmount: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rds_logs_amount"),
-			"The amount of existent log files",
-			[]string{"aws_region", "dbinstance_identifier"},
-			nil,
-		),
-		logger:   logger,
-		cache:    *NewMetricsCache(*config.CacheTTL),
-		interval: *config.Interval,
+		logger:         logger,
+		cache:          *NewMetricsCache(*config.CacheTTL),
+		interval:       *config.Interval,
+		timeout:        *config.Timeout,
 	}
 }
 
@@ -346,63 +339,49 @@ func (e *RDSExporter) getRegion(sessionIndex int) string {
 	return *e.sessions[sessionIndex].Config.Region
 }
 
-func (e *RDSExporter) requestRDSLogMetrics(sessionIndex int, instanceId string) (*RDSLogsMetrics, error) {
+func (e *RDSExporter) requestRDSLogMetrics(ctx context.Context, sessionIndex int, instanceId string) (*RDSLogsMetrics, error) {
 	var logMetrics = &RDSLogsMetrics{
 		logs:         0,
 		totalLogSize: 0,
 	}
-	var input = &rds.DescribeDBLogFilesInput{
-		DBInstanceIdentifier: &instanceId,
+
+	logOutPuts, err := e.svcs[sessionIndex].DescribeDBLogFilesAll(ctx, instanceId)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Call to DescribeDBLogFiles failed", "region", e.getRegion(sessionIndex), "instance", &instanceId, "err", err)
+		AwsExporterMetrics.IncrementErrors()
+		return nil, err
 	}
 
-	for {
-		AwsExporterMetrics.IncrementRequests()
-		result, err := e.svcs[sessionIndex].DescribeDBLogFiles(input)
-		if err != nil {
-			level.Error(e.logger).Log("msg", "Call to DescribeDBLogFiles failed", "region", e.getRegion(sessionIndex), "instance", &instanceId, "err", err)
-			AwsExporterMetrics.IncrementErrors()
-			return nil, err
-		}
-		for _, log := range result.DescribeDBLogFiles {
+	for _, outputs := range logOutPuts {
+		for _, log := range outputs.DescribeDBLogFiles {
 			logMetrics.logs++
 			logMetrics.totalLogSize += *log.Size
 		}
-		input.Marker = result.Marker
-		if result.Marker == nil {
-			break
-		}
+
 	}
+
 	return logMetrics, nil
 }
 
-func (e *RDSExporter) getRDSLogMetrics(sessionIndex int, instanceId string) error {
+func (e *RDSExporter) addRDSLogMetrics(ctx context.Context, sessionIndex int, instanceId string) error {
 	instaceLogFilesId := instanceId + "-" + "logfiles"
 	var logMetrics *RDSLogsMetrics
 	cachedItem, err := metricsProxy.GetMetricById(instaceLogFilesId)
 	if err != nil {
-		level.Debug(e.logger).Log("msg", "Log files metrics can not be fetched from the metrics proxy --> Api Call",
-			"instance", instanceId,
-			"err", err,
-		)
-		logMetrics, err = e.requestRDSLogMetrics(sessionIndex, instanceId)
+		logMetrics, err = e.requestRDSLogMetrics(ctx, sessionIndex, instanceId)
 		if err != nil {
-			level.Debug(e.logger).Log("msg", "Cancelling context and exiting worker due to an getLogfilesMetrics error")
 			return err
 		}
 		metricsProxy.StoreMetricById(instaceLogFilesId, logMetrics, e.logsMetricsTTL)
 	} else {
-		level.Debug(e.logger).Log("msg", "Log files metrics fetched from the metrics proxy",
-			"instance", instanceId,
-			"ttl", float64(cachedItem.ttl)-time.Since(cachedItem.creationTime).Seconds(),
-		)
 		logMetrics = cachedItem.value.(*RDSLogsMetrics)
 	}
-	e.cache.AddMetric(prometheus.MustNewConstMetric(e.LogsAmount, prometheus.GaugeValue, float64(logMetrics.logs), e.getRegion(sessionIndex), instanceId))
-	e.cache.AddMetric(prometheus.MustNewConstMetric(e.LogsStorageSize, prometheus.GaugeValue, float64(logMetrics.totalLogSize), e.getRegion(sessionIndex), instanceId))
+	e.cache.AddMetric(prometheus.MustNewConstMetric(LogsAmount, prometheus.GaugeValue, float64(logMetrics.logs), e.getRegion(sessionIndex), instanceId))
+	e.cache.AddMetric(prometheus.MustNewConstMetric(LogsStorageSize, prometheus.GaugeValue, float64(logMetrics.totalLogSize), e.getRegion(sessionIndex), instanceId))
 	return nil
 }
 
-func (e *RDSExporter) collectLogMetrics(sessionIndex int, instances []*rds.DBInstance) {
+func (e *RDSExporter) addAllLogMetrics(ctx context.Context, sessionIndex int, instances []*rds.DBInstance) {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(instances))
 
@@ -417,13 +396,13 @@ func (e *RDSExporter) collectLogMetrics(sessionIndex int, instances []*rds.DBIns
 				<-sem
 				wg.Done()
 			}()
-			e.getRDSLogMetrics(sessionIndex, instanceName)
+			e.addRDSLogMetrics(ctx, sessionIndex, instanceName)
 		}(*instance.DBInstanceIdentifier)
 	}
 	wg.Wait()
 }
 
-func (e *RDSExporter) addInstanceMetrics(sessionIndex int, instances []*rds.DBInstance) {
+func (e *RDSExporter) addAllInstanceMetrics(sessionIndex int, instances []*rds.DBInstance) {
 	for _, instance := range instances {
 		var maxConnections int64
 		if valmap, ok := DBMaxConnections[*instance.DBInstanceClass]; ok {
@@ -442,64 +421,54 @@ func (e *RDSExporter) addInstanceMetrics(sessionIndex int, instances []*rds.DBIn
 					"group", *instance.DBParameterGroups[0].DBParameterGroupName,
 					"value", maxconn)
 				maxConnections = maxconn
-				e.cache.AddMetric(prometheus.MustNewConstMetric(e.MaxConnectionsMappingError, prometheus.GaugeValue, 0, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
+				e.cache.AddMetric(prometheus.MustNewConstMetric(MaxConnectionsMappingError, prometheus.GaugeValue, 0, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
 			} else {
 				level.Error(e.logger).Log("msg", "No DB max_connections mapping exists for instance",
 					"type", *instance.DBInstanceClass,
 					"group", *instance.DBParameterGroups[0].DBParameterGroupName)
-				e.cache.AddMetric(prometheus.MustNewConstMetric(e.MaxConnectionsMappingError, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
+				e.cache.AddMetric(prometheus.MustNewConstMetric(MaxConnectionsMappingError, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
 			}
 		} else {
 			level.Error(e.logger).Log("msg", "No DB max_connections mapping exists for instance",
 				"type", *instance.DBInstanceClass)
-			e.cache.AddMetric(prometheus.MustNewConstMetric(e.MaxConnectionsMappingError, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
+			e.cache.AddMetric(prometheus.MustNewConstMetric(MaxConnectionsMappingError, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
 		}
 
 		var public = 0.0
 		if *instance.PubliclyAccessible {
 			public = 1.0
 		}
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.PubliclyAccessible, prometheus.GaugeValue, public, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(PubliclyAccessible, prometheus.GaugeValue, public, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
 
 		var encrypted = 0.0
 		if *instance.StorageEncrypted {
 			encrypted = 1.0
 		}
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.StorageEncrypted, prometheus.GaugeValue, encrypted, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(StorageEncrypted, prometheus.GaugeValue, encrypted, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
 
 		var restoreTime = 0.0
 		if instance.LatestRestorableTime != nil {
 			restoreTime = float64(instance.LatestRestorableTime.Unix())
 		}
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.LatestRestorableTime, prometheus.CounterValue, restoreTime, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(LatestRestorableTime, prometheus.CounterValue, restoreTime, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
 
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.MaxConnections, prometheus.GaugeValue, float64(maxConnections), e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.AllocatedStorage, prometheus.GaugeValue, float64(*instance.AllocatedStorage*1024*1024*1024), e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.DBInstanceStatus, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceStatus))
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.EngineVersion, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.Engine, *instance.EngineVersion))
-		e.cache.AddMetric(prometheus.MustNewConstMetric(e.DBInstanceClass, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(MaxConnections, prometheus.GaugeValue, float64(maxConnections), e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(AllocatedStorage, prometheus.GaugeValue, float64(*instance.AllocatedStorage*1024*1024*1024), e.getRegion(sessionIndex), *instance.DBInstanceIdentifier))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(DBInstanceStatus, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceStatus))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(EngineVersion, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.Engine, *instance.EngineVersion))
+		e.cache.AddMetric(prometheus.MustNewConstMetric(DBInstanceClass, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.DBInstanceClass))
 	}
 }
 
-func (e *RDSExporter) collectPendingMaintenances(sessionIndex int, instances []*rds.DBInstance) {
+func (e *RDSExporter) addAllPendingMaintenancesMetrics(ctx context.Context, sessionIndex int, instances []*rds.DBInstance) {
 	// Get pending maintenance data because this isn't provided in DescribeDBInstances
-	var instancesPendMaintActionsData []*rds.ResourcePendingMaintenanceActions
-	describePendingMaintInput := &rds.DescribePendingMaintenanceActionsInput{}
 	instancesWithPendingMaint := make(map[string]bool)
 
-	for {
-		AwsExporterMetrics.IncrementRequests()
-		result, err := e.svcs[sessionIndex].DescribePendingMaintenanceActions(describePendingMaintInput)
-		if err != nil {
-			level.Error(e.logger).Log("msg", "Call to DescribePendingMaintenanceActions failed", "region", e.getRegion(sessionIndex), "err", err)
-			AwsExporterMetrics.IncrementErrors()
-			return
-		}
-		instancesPendMaintActionsData = append(instancesPendMaintActionsData, result.PendingMaintenanceActions...)
-		describePendingMaintInput.Marker = result.Marker
-		if result.Marker == nil {
-			break
-		}
+	instancesPendMaintActionsData, err := e.svcs[sessionIndex].DescribePendingMaintenanceActionsAll(ctx)
+
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Call to DescribePendingMaintenanceActions failed", "region", e.getRegion(sessionIndex), "err", err)
+		return
 	}
 
 	// Create the metrics for all instances that have pending maintenance actions
@@ -519,7 +488,7 @@ func (e *RDSExporter) collectPendingMaintenances(sessionIndex int, instances []*
 				currentApplyDate = action.CurrentApplyDate.String()
 			}
 
-			e.cache.AddMetric(prometheus.MustNewConstMetric(e.PendingMaintenanceActions, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), dbIdentifier, *action.Action, autoApplyDate, currentApplyDate, *action.Description))
+			e.cache.AddMetric(prometheus.MustNewConstMetric(PendingMaintenanceActions, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), dbIdentifier, *action.Action, autoApplyDate, currentApplyDate, *action.Description))
 		}
 	}
 
@@ -528,7 +497,7 @@ func (e *RDSExporter) collectPendingMaintenances(sessionIndex int, instances []*
 	// available.
 	for _, instance := range instances {
 		if !instancesWithPendingMaint[*instance.DBInstanceIdentifier] {
-			e.cache.AddMetric(prometheus.MustNewConstMetric(e.PendingMaintenanceActions, prometheus.GaugeValue, 0, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, "", "", "", ""))
+			e.cache.AddMetric(prometheus.MustNewConstMetric(PendingMaintenanceActions, prometheus.GaugeValue, 0, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, "", "", "", ""))
 		}
 	}
 
@@ -536,48 +505,42 @@ func (e *RDSExporter) collectPendingMaintenances(sessionIndex int, instances []*
 
 // Describe is used by the Prometheus client to return a description of the metrics
 func (e *RDSExporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.AllocatedStorage
-	ch <- e.DBInstanceClass
-	ch <- e.DBInstanceStatus
-	ch <- e.EngineVersion
-	ch <- e.LatestRestorableTime
-	ch <- e.MaxConnections
-	ch <- e.MaxConnectionsMappingError
-	ch <- e.PendingMaintenanceActions
-	ch <- e.PubliclyAccessible
-	ch <- e.StorageEncrypted
+	ch <- AllocatedStorage
+	ch <- DBInstanceClass
+	ch <- DBInstanceStatus
+	ch <- EngineVersion
+	ch <- LatestRestorableTime
+	ch <- MaxConnections
+	ch <- MaxConnectionsMappingError
+	ch <- PendingMaintenanceActions
+	ch <- PubliclyAccessible
+	ch <- StorageEncrypted
 }
 
 func (e *RDSExporter) CollectLoop() {
 	for {
+		ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 		for i, _ := range e.sessions {
-			input := &rds.DescribeDBInstancesInput{}
 
-			var instances []*rds.DBInstance
-			err := e.svcs[i].DescribeDBInstancesPages(input, func(ddo *rds.DescribeDBInstancesOutput, b bool) bool {
-				AwsExporterMetrics.IncrementRequests()
-				instances = append(instances, ddo.DBInstances...)
-				return true
-			})
+			instances, err := e.svcs[i].DescribeDBInstancesAll(ctx)
 			if err != nil {
 				level.Error(e.logger).Log("msg", "Call to DescribeDBInstances failed", "region", *e.sessions[i].Config.Region, "err", err)
 				AwsExporterMetrics.IncrementErrors()
-				return
 			}
 
 			wg := sync.WaitGroup{}
 			wg.Add(3)
 
 			go func() {
-				e.addInstanceMetrics(i, instances)
+				e.addAllInstanceMetrics(i, instances)
 				wg.Done()
 			}()
 			go func() {
-				e.collectLogMetrics(i, instances)
+				e.addAllLogMetrics(ctx, i, instances)
 				wg.Done()
 			}()
 			go func() {
-				e.collectPendingMaintenances(i, instances)
+				e.addAllPendingMaintenancesMetrics(ctx, i, instances)
 				wg.Done()
 			}()
 			wg.Wait()
@@ -585,6 +548,7 @@ func (e *RDSExporter) CollectLoop() {
 
 		level.Info(e.logger).Log("msg", "RDS metrics Updated")
 
+		cancel()
 		time.Sleep(e.interval)
 	}
 }

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -1,0 +1,152 @@
+package pkg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/app-sre/aws-resource-exporter/pkg/awsclient"
+	"github.com/app-sre/aws-resource-exporter/pkg/awsclient/mock"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/go-kit/kit/log"
+	"github.com/golang/mock/gomock"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestDBInstances() []*rds.DBInstance {
+	return []*rds.DBInstance{
+		{
+			DBInstanceIdentifier: aws.String("footest"),
+			DBInstanceClass:      aws.String("db.m5.xlarge"),
+			DBParameterGroups:    []*rds.DBParameterGroupStatus{{DBParameterGroupName: aws.String("default.postgres14")}},
+			PubliclyAccessible:   aws.Bool(false),
+			StorageEncrypted:     aws.Bool(false),
+			AllocatedStorage:     aws.Int64(1024),
+			DBInstanceStatus:     aws.String("on fire"),
+			Engine:               aws.String("SQL"),
+			EngineVersion:        aws.String("1000"),
+		},
+	}
+}
+
+func TestRequestRDSLogMetrics(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().DescribeDBLogFilesAll(ctx, "footest").Return([]*rds.DescribeDBLogFilesOutput{
+		{DescribeDBLogFiles: []*rds.DescribeDBLogFilesDetails{{Size: aws.Int64(123)}, {Size: aws.Int64(123)}}},
+		{DescribeDBLogFiles: []*rds.DescribeDBLogFilesDetails{{Size: aws.Int64(1)}}},
+	}, nil)
+
+	x := RDSExporter{
+		svcs: []awsclient.Client{mockClient},
+	}
+
+	metrics, err := x.requestRDSLogMetrics(ctx, 0, "footest")
+	assert.Equal(t, int64(247), metrics.totalLogSize)
+	assert.Equal(t, 3, metrics.logs)
+	assert.Nil(t, err)
+}
+
+func TestAddRDSLogMetrics(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().DescribeDBLogFilesAll(ctx, "footest").Return([]*rds.DescribeDBLogFilesOutput{
+		{DescribeDBLogFiles: []*rds.DescribeDBLogFilesDetails{{Size: aws.Int64(123)}, {Size: aws.Int64(123)}}},
+		{DescribeDBLogFiles: []*rds.DescribeDBLogFilesDetails{{Size: aws.Int64(1)}}},
+	}, nil)
+
+	x := RDSExporter{
+		svcs:     []awsclient.Client{mockClient},
+		sessions: []*session.Session{session.New(&aws.Config{Region: aws.String("foo")})},
+		cache:    *NewMetricsCache(10 * time.Second),
+	}
+
+	err := x.addRDSLogMetrics(ctx, 0, "footest")
+	assert.Len(t, x.cache.GetAllMetrics(), 2)
+	assert.Nil(t, err)
+}
+
+func TestAddAllInstanceMetrics(t *testing.T) {
+	x := RDSExporter{
+		sessions: []*session.Session{session.New(&aws.Config{Region: aws.String("foo")})},
+		cache:    *NewMetricsCache(10 * time.Second),
+		logger:   log.NewNopLogger(),
+	}
+
+	var instances = []*rds.DBInstance{}
+	x.addAllInstanceMetrics(0, instances)
+	assert.Len(t, x.cache.GetAllMetrics(), 0)
+
+	x.addAllInstanceMetrics(0, createTestDBInstances())
+	assert.Len(t, x.cache.GetAllMetrics(), 9)
+}
+
+func TestAddAllPendingMaintenancesMetrics(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().DescribePendingMaintenanceActionsAll(ctx).Return([]*rds.ResourcePendingMaintenanceActions{
+		{
+			PendingMaintenanceActionDetails: []*rds.PendingMaintenanceAction{{
+				Action:      aws.String("something going on"),
+				Description: aws.String("plumbing"),
+			}},
+			ResourceIdentifier: aws.String("::::::footest"),
+		},
+	}, nil)
+
+	x := RDSExporter{
+		svcs:     []awsclient.Client{mockClient},
+		sessions: []*session.Session{session.New(&aws.Config{Region: aws.String("foo")})},
+		cache:    *NewMetricsCache(10 * time.Second),
+		logger:   log.NewNopLogger(),
+	}
+
+	x.addAllPendingMaintenancesMetrics(ctx, 0, createTestDBInstances())
+	metrics := x.cache.GetAllMetrics()
+	assert.Len(t, metrics, 1)
+
+	var dto dto.Metric
+	metrics[0].Write(&dto)
+
+	// Expecting a maintenance, thus value 1
+	assert.Equal(t, float64(1), *dto.Gauge.Value)
+
+}
+
+func TestAddAllPendingMaintenancesNoMetrics(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock.NewMockClient(ctrl)
+	mockClient.EXPECT().DescribePendingMaintenanceActionsAll(ctx).Return([]*rds.ResourcePendingMaintenanceActions{}, nil)
+
+	x := RDSExporter{
+		svcs:     []awsclient.Client{mockClient},
+		sessions: []*session.Session{session.New(&aws.Config{Region: aws.String("foo")})},
+		cache:    *NewMetricsCache(10 * time.Second),
+		logger:   log.NewNopLogger(),
+	}
+
+	x.addAllPendingMaintenancesMetrics(ctx, 0, createTestDBInstances())
+	metrics := x.cache.GetAllMetrics()
+	assert.Len(t, metrics, 1)
+
+	var dto dto.Metric
+	metrics[0].Write(&dto)
+
+	// Expecting no maintenance, thus 0 value
+	assert.Equal(t, float64(0), *dto.Gauge.Value)
+}

--- a/pkg/route53.go
+++ b/pkg/route53.go
@@ -81,7 +81,7 @@ func (e *Route53Exporter) getRecordsPerHostedZoneMetrics(client *route53.Route53
 
 			if err != nil {
 				errChan <- fmt.Errorf("Could not get Limits for hosted zone with ID '%s' and name '%s'. Error was: %s", *hostedZone.Id, *hostedZone.Name, err.Error())
-				AwsExporterMetrics.IncrementErrors()
+				awsclient.AwsExporterMetrics.IncrementErrors()
 				return
 			}
 			level.Info(e.logger).Log("msg", fmt.Sprintf("Currently at hosted zone: %d / %d", i, len(hostedZones)))
@@ -126,19 +126,19 @@ func (e *Route53Exporter) CollectLoop() {
 		level.Info(e.logger).Log("msg", "Got all zones")
 		if err != nil {
 			level.Error(e.logger).Log("msg", "Could not retrieve the list of hosted zones", "error", err.Error())
-			AwsExporterMetrics.IncrementErrors()
+			awsclient.AwsExporterMetrics.IncrementErrors()
 		}
 
 		err = e.getHostedZonesPerAccountMetrics(client, hostedZones, ctx)
 		if err != nil {
 			level.Error(e.logger).Log("msg", "Could not get limits for hosted zone", "error", err.Error())
-			AwsExporterMetrics.IncrementErrors()
+			awsclient.AwsExporterMetrics.IncrementErrors()
 		}
 
 		errs := e.getRecordsPerHostedZoneMetrics(route53Svc, hostedZones, ctx)
 		for _, err = range errs {
 			level.Error(e.logger).Log("msg", "Could not get limits for hosted zone", "error", err.Error())
-			AwsExporterMetrics.IncrementErrors()
+			awsclient.AwsExporterMetrics.IncrementErrors()
 		}
 
 		level.Info(e.logger).Log("msg", "Route53 metrics Updated")

--- a/pkg/vpc.go
+++ b/pkg/vpc.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/app-sre/aws-resource-exporter/pkg/awsclient"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -160,7 +161,7 @@ func (e *VPCExporter) collectVpcsPerRegionQuota(client *servicequotas.ServiceQuo
 	quota, err := e.GetQuotaValue(client, SERVICE_CODE_VPC, QUOTA_VPCS_PER_REGION)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to VpcsPerRegion ServiceQuota failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	e.cache.AddMetric(prometheus.MustNewConstMetric(e.VpcsPerRegionQuota, prometheus.GaugeValue, quota, region))
@@ -172,7 +173,7 @@ func (e *VPCExporter) collectVpcsPerRegionUsage(ec2Svc *ec2.EC2, region string) 
 	describeVpcsOutput, err := ec2Svc.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{})
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeVpcs failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	usage := len(describeVpcsOutput.Vpcs)
@@ -183,7 +184,7 @@ func (e *VPCExporter) collectSubnetsPerVpcQuota(client *servicequotas.ServiceQuo
 	quota, err := e.GetQuotaValue(client, SERVICE_CODE_VPC, QUOTA_SUBNETS_PER_VPC)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to SubnetsPerVpc ServiceQuota failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	e.cache.AddMetric(prometheus.MustNewConstMetric(e.SubnetsPerVpcQuota, prometheus.GaugeValue, quota, region))
@@ -200,7 +201,7 @@ func (e *VPCExporter) collectSubnetsPerVpcUsage(vpc *ec2.Vpc, ec2Svc *ec2.EC2, r
 	})
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeSubnets failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	usage := len(describeSubnetsOutput.Subnets)
@@ -211,7 +212,7 @@ func (e *VPCExporter) collectRoutesPerRouteTableQuota(client *servicequotas.Serv
 	quota, err := e.GetQuotaValue(client, SERVICE_CODE_VPC, QUOTA_ROUTES_PER_ROUTE_TABLE)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to RoutesPerRouteTable ServiceQuota failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	e.cache.AddMetric(prometheus.MustNewConstMetric(e.RoutesPerRouteTableQuota, prometheus.GaugeValue, quota, region))
@@ -225,7 +226,7 @@ func (e *VPCExporter) collectRoutesPerRouteTableUsage(rtb *ec2.RouteTable, ec2Sv
 	})
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeRouteTables failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	quota := len(descRouteTableOutput.RouteTables)
@@ -236,7 +237,7 @@ func (e *VPCExporter) collectInterfaceVpcEndpointsPerVpcQuota(client *servicequo
 	quota, err := e.GetQuotaValue(client, SERVICE_CODE_VPC, QUOTA_INTERFACE_VPC_ENDPOINTS_PER_VPC)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to InterfaceVpcEndpointsPerVpc ServiceQuota failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	e.cache.AddMetric(prometheus.MustNewConstMetric(e.InterfaceVpcEndpointsPerVpcQuota, prometheus.GaugeValue, quota, region))
@@ -253,7 +254,7 @@ func (e *VPCExporter) collectInterfaceVpcEndpointsPerVpcUsage(vpc *ec2.Vpc, ec2S
 	})
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeVpcEndpoints failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	quota := len(descVpcEndpoints.VpcEndpoints)
@@ -264,7 +265,7 @@ func (e *VPCExporter) collectRoutesTablesPerVpcQuota(client *servicequotas.Servi
 	quota, err := e.GetQuotaValue(client, SERVICE_CODE_VPC, QUOTA_ROUTE_TABLES_PER_VPC)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to RoutesTablesPerVpc ServiceQuota failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	e.cache.AddMetric(prometheus.MustNewConstMetric(e.RouteTablesPerVpcQuota, prometheus.GaugeValue, quota, region))
@@ -281,7 +282,7 @@ func (e *VPCExporter) collectRoutesTablesPerVpcUsage(vpc *ec2.Vpc, ec2Svc *ec2.E
 	})
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeRouteTables failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	quota := len(descRouteTables.RouteTables)
@@ -292,7 +293,7 @@ func (e *VPCExporter) collectIPv4BlocksPerVpcQuota(client *servicequotas.Service
 	quota, err := e.GetQuotaValue(client, SERVICE_CODE_VPC, QUOTA_IPV4_BLOCKS_PER_VPC)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to IPv4BlocksPerVpc ServiceQuota failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	e.cache.AddMetric(prometheus.MustNewConstMetric(e.IPv4BlocksPerVpcQuota, prometheus.GaugeValue, quota, region))
@@ -306,7 +307,7 @@ func (e *VPCExporter) collectIPv4BlocksPerVpcUsage(vpc *ec2.Vpc, ec2Svc *ec2.EC2
 	})
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Call to DescribeVpcs failed", "region", region, "err", err)
-		AwsExporterMetrics.IncrementErrors()
+		awsclient.AwsExporterMetrics.IncrementErrors()
 		return
 	}
 	if len(descVpcs.Vpcs) != 1 {


### PR DESCRIPTION
Refactoring to enable testing, split up CollectLoop:

 * Move corrosponding code sections into individual methods
 * Make individual methods concurrent to speed up metrics collection
 * Refactor collectLogMetrics adapt concurrency to match pattern established in route53.go
 * Needed to refactor to be able to mock out AWS results. Reason being is the switch to pagination methods. Created new *All methods in awsclient.go. By adding them to the inteface, it is possible to mock out the result for these paginated methods.
* Next refactoring was to make the fields in the RDSExporter struct simple variables, that way the tests can create simple RDSExporter objects that support only single tests cases. Otherwise, the NewRDSExporter Methods would have required some substantial refactoring.
* In the end added a couple of basic tests
* The last commit seems unrelated to adding tests but is required to restore the API request count. It moves the AwsExporterMetrics into the awsclient with the corresponding consequences. 

Going commit by commit could make the review simpler.

related ticket: https://issues.redhat.com/browse/APPSRE-6310