### PR TITLE
Add rds eol date and status

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -19,7 +19,14 @@ type BaseConfig struct {
 
 type RDSConfig struct {
 	BaseConfig `yaml:"base,inline"`
-	Regions    []string `yaml:"regions"`
+	Regions    []string  `yaml:"regions"`
+	EOLInfos   []EOLInfo `yaml:"eol_info"`
+}
+
+type EOLInfo struct {
+	Engine  string `yaml:"engine"`
+	EOL     string `yaml:"eol"`
+	Version string `yaml:"version"`
 }
 
 type VPCConfig struct {
@@ -91,5 +98,6 @@ func LoadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 	if config.EC2Config.Timeout == nil {
 		config.EC2Config.Timeout = durationPtr(10 * time.Second)
 	}
+
 	return &config, nil
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -29,6 +29,11 @@ type EOLInfo struct {
 	Version string `yaml:"version"`
 }
 
+type EOLKey struct {
+	Engine  string
+	Version string
+}
+
 type VPCConfig struct {
 	BaseConfig `yaml:"base,inline"`
 	Regions    []string `yaml:"regions"`

--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -298,8 +298,6 @@ var DBMaxConnections = map[string]map[string]int64{
 	},
 }
 
-// var eolMap = make(map[string]map[string]EOLInfo)
-
 var AllocatedStorage *prometheus.Desc = prometheus.NewDesc(
 	prometheus.BuildFQName(namespace, "", "rds_allocatedstorage"),
 	"The amount of allocated storage in bytes.",
@@ -375,13 +373,13 @@ var LogsAmount *prometheus.Desc = prometheus.NewDesc(
 var EOLDate *prometheus.Desc = prometheus.NewDesc(
 	prometheus.BuildFQName(namespace, "", "rds_eol"),
 	"The EOL date for the DB engine type and version.",
-	[]string{"aws_region", "dbinstance_identifier", "engine", "engine_version"},
+	[]string{"aws_region", "dbinstance_identifier", "engine", "engine_version", "eol_date"},
 	nil,
 )
 var EOLStatus *prometheus.Desc = prometheus.NewDesc(
 	prometheus.BuildFQName(namespace, "", "rds_eolstatus"),
 	"The status of the EOL date for the DB engine type and version.",
-	[]string{"aws_region", "dbinstance_identifier", "engine", "engine_version"},
+	[]string{"aws_region", "dbinstance_identifier", "engine", "engine_version", "eol_status"},
 	nil,
 )
 
@@ -556,7 +554,7 @@ func (e *RDSExporter) addAllInstanceMetrics(sessionIndex int, instances []*rds.D
 				//Add empty eol status?
 			}
 			level.Info(e.logger).Log("msg", fmt.Sprintf("EOL Status: %s\n", eolStatus))
-			e.cache.AddMetric(prometheus.MustNewConstMetric(EOLDate, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.Engine, *instance.EngineVersion, eolStatus))
+			e.cache.AddMetric(prometheus.MustNewConstMetric(EOLStatus, prometheus.GaugeValue, 1, e.getRegion(sessionIndex), *instance.DBInstanceIdentifier, *instance.Engine, *instance.EngineVersion, eolStatus))
 		} else {
 			//Add empty EOL value?
 			level.Info(e.logger).Log("msg", fmt.Sprintf("EOL not found for Engine %s, Version %s\n", *instance.Engine, *instance.EngineVersion))
@@ -589,8 +587,8 @@ func (e *RDSExporter) addAllInstanceMetrics(sessionIndex int, instances []*rds.D
 
 }
 
-func getEOLStatus(eolInfo string) (string, error) {
-	eolDate, err := time.Parse("2006-01-02", eolInfo)
+func getEOLStatus(eol string) (string, error) {
+	eolDate, err := time.Parse("2006-01-02", eol)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -108,7 +108,6 @@ func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {
 		{Engine: "SQL", Version: "1000", EOL: "2023-12-01"},
 	}
 
-	// Invoke the function to add metrics
 	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
 
 	// Retrieve the EOLDate metric value from the cache
@@ -117,7 +116,6 @@ func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {
 		t.Fatalf("Error retrieving EOLDate metric value: %v", err)
 	}
 
-	// Define the expected EOLDate value
 	expectedEOLDate := "2023-12-01"
 
 	// Compare the actual EOLDate value to the expected value

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -85,8 +85,9 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 
 	var instances = []*rds.DBInstance{}
 
+	//No match
 	eolInfos := []EOLInfo{
-		{Engine: "SQL", Version: "1000", EOL: "2023-12-01"},
+		{Engine: "engine", Version: "123", EOL: "2023-12-01"},
 	}
 
 	x.addAllInstanceMetrics(0, instances, eolInfos)

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -83,11 +84,101 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 	}
 
 	var instances = []*rds.DBInstance{}
-	x.addAllInstanceMetrics(0, instances)
+
+	eolInfos := []EOLInfo{
+		{Engine: "engine1", Version: "123", EOL: "2023-12-01"},
+		{Engine: "engine2", Version: "456", EOL: "2024-09-01"},
+	}
+
+	x.addAllInstanceMetrics(0, instances, eolInfos)
 	assert.Len(t, x.cache.GetAllMetrics(), 0)
 
-	x.addAllInstanceMetrics(0, createTestDBInstances())
+	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
 	assert.Len(t, x.cache.GetAllMetrics(), 9)
+}
+
+func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {
+	x := RDSExporter{
+		sessions: []*session.Session{session.New(&aws.Config{Region: aws.String("foo")})},
+		cache:    *NewMetricsCache(10 * time.Second),
+		logger:   log.NewNopLogger(),
+	}
+
+	eolInfos := []EOLInfo{
+		{Engine: "SQL", Version: "1000", EOL: "2023-12-01"},
+	}
+
+	// Invoke the function to add metrics
+	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
+
+	// Retrieve the EOLDate metric value from the cache
+	eolDateMetricValue, err := getEOLDateMetricValue(&x)
+	if err != nil {
+		t.Fatalf("Error retrieving EOLDate metric value: %v", err)
+	}
+
+	// Define the expected EOLDate value
+	expectedEOLDate := "2023-12-01"
+
+	// Compare the actual EOLDate value to the expected value
+	if eolDateMetricValue != expectedEOLDate {
+		t.Errorf("EOLDate metric has an unexpected value. Expected: %s, Actual: %s", expectedEOLDate, eolDateMetricValue)
+	}
+}
+
+// Helper function to retrieve the EOLDate metric value from the cache
+func getEOLDateMetricValue(x *RDSExporter) (string, error) {
+	metrics := x.cache.GetAllMetrics()
+	for _, metric := range metrics {
+		if metric.Desc().String() == EOLDate.String() { // Compare with EOLDate descriptor
+			dto := &dto.Metric{}
+			if err := metric.Write(dto); err != nil {
+				return "", err
+			}
+			labels := dto.GetLabel()
+			if len(labels) > 0 {
+				return labels[4].GetValue(), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("EOLDate metric not found")
+}
+
+func TestGetEOLStatus(t *testing.T) {
+	// EOL date is within 90 days
+	eol := time.Now().Add(2 * 24 * time.Hour).Format("2006-01-02")
+	expectedStatus := "red"
+	status, err := getEOLStatus(eol)
+	if err != nil {
+		t.Errorf("Expected no error, but got an error: %v", err)
+	}
+	if status != expectedStatus {
+		t.Errorf("Expected status '%s', but got '%s'", expectedStatus, status)
+	}
+
+	// EOL date is within 180 days
+	eol = time.Now().Add(120 * 24 * time.Hour).Format("2006-01-02")
+	expectedStatus = "yellow"
+	status, err = getEOLStatus(eol)
+	if err != nil {
+		t.Errorf("Expected no error, but got an error: %v", err)
+	}
+	if status != expectedStatus {
+		t.Errorf("Expected status '%s', but got '%s'", expectedStatus, status)
+	}
+
+	// EOL date is more than 180 days
+
+	eol = time.Now().Add(200 * 24 * time.Hour).Format("2006-01-02")
+	expectedStatus = "green"
+	status, err = getEOLStatus(eol)
+	if err != nil {
+		t.Errorf("Expected no error, but got an error: %v", err)
+	}
+	if status != expectedStatus {
+		t.Errorf("Expected status '%s', but got '%s'", expectedStatus, status)
+	}
+
 }
 
 func TestAddAllPendingMaintenancesMetrics(t *testing.T) {

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -86,8 +86,7 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 	var instances = []*rds.DBInstance{}
 
 	eolInfos := []EOLInfo{
-		{Engine: "engine1", Version: "123", EOL: "2023-12-01"},
-		{Engine: "engine2", Version: "456", EOL: "2024-09-01"},
+		{Engine: "SQL", Version: "1000", EOL: "2023-12-01"},
 	}
 
 	x.addAllInstanceMetrics(0, instances, eolInfos)

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -85,7 +85,7 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 
 	var instances = []*rds.DBInstance{}
 
-	//No match
+	// Test with no match
 	eolInfos := []EOLInfo{
 		{Engine: "engine", Version: "123", EOL: "2023-12-01"},
 	}
@@ -110,36 +110,81 @@ func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {
 
 	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
 
-	// Retrieve the EOLDate metric value from the cache
 	eolDateMetricValue, err := getEOLDateMetricValue(&x)
 	if err != nil {
-		t.Fatalf("Error retrieving EOLDate metric value: %v", err)
+		t.Errorf("Error retrieving EOLDate metric value: %v", err)
 	}
 
 	expectedEOLDate := "2023-12-01"
 
-	// Compare the actual EOLDate value to the expected value
 	if eolDateMetricValue != expectedEOLDate {
 		t.Errorf("EOLDate metric has an unexpected value. Expected: %s, Actual: %s", expectedEOLDate, eolDateMetricValue)
+	}
+}
+
+func TestAddAllInstanceMetricsWithGetEOLStatusError(t *testing.T) {
+	x := RDSExporter{
+		sessions: []*session.Session{session.New(&aws.Config{Region: aws.String("foo")})},
+		cache:    *NewMetricsCache(10 * time.Second),
+		logger:   log.NewNopLogger(),
+	}
+
+	eolInfos := []EOLInfo{
+		{Engine: "SQL", Version: "1000", EOL: "invalid-date"},
+	}
+
+	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
+
+	_, err := getEOLStatusMetricValue(&x)
+	if err == nil {
+		t.Error("Expected an error from getEOLStatusMetricValue but got none")
+	} else {
+		t.Logf("Expected error received from getEOLStatusMetricValue: %v", err)
 	}
 }
 
 // Helper function to retrieve the EOLDate metric value from the cache
 func getEOLDateMetricValue(x *RDSExporter) (string, error) {
 	metrics := x.cache.GetAllMetrics()
+	metricDescription := EOLDate.String()
+
 	for _, metric := range metrics {
-		if metric.Desc().String() == EOLDate.String() { // Compare with EOLDate descriptor
+		if metric.Desc().String() == metricDescription {
 			dto := &dto.Metric{}
 			if err := metric.Write(dto); err != nil {
 				return "", err
 			}
-			labels := dto.GetLabel()
-			if len(labels) > 0 {
-				return labels[4].GetValue(), nil
+			for _, label := range dto.GetLabel() {
+				if label.GetName() == "eol_date" {
+					return label.GetValue(), nil
+				}
 			}
+			return "", fmt.Errorf("eol_date label not found for EOLDate metric")
 		}
 	}
 	return "", fmt.Errorf("EOLDate metric not found")
+}
+
+// Helper function to retrieve the EOLStatus metric value from the cache
+func getEOLStatusMetricValue(x *RDSExporter) (string, error) {
+	metrics := x.cache.GetAllMetrics()
+	metricDescription := EOLStatus.String()
+
+	for _, metric := range metrics {
+		if metric.Desc().String() == metricDescription {
+			dto := &dto.Metric{}
+			if err := metric.Write(dto); err != nil {
+				return "", err
+			}
+			for _, label := range dto.GetLabel() {
+				if label.GetName() == "eol_status" {
+					return label.GetValue(), nil
+				}
+			}
+			return "", fmt.Errorf("eol_status label not found for EOLStatus metric")
+		}
+	}
+	return "", fmt.Errorf("EOLStatus metric not found")
 }
 
 func TestGetEOLStatus(t *testing.T) {
@@ -166,7 +211,6 @@ func TestGetEOLStatus(t *testing.T) {
 	}
 
 	// EOL date is more than 180 days
-
 	eol = time.Now().Add(200 * 24 * time.Hour).Format("2006-01-02")
 	expectedStatus = "green"
 	status, err = getEOLStatus(eol)


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-8429

Adds RDS EOL date and status metrics to enable alerting for tenants to upgrade their RDS instances when approaching EOL.

EOL data is retrieved from the aws-resource-exporter configmap.