### PR TITLE
Add AWS account info to RDS EngineVersion metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func setupCollectors(logger log.Logger, configFile string) ([]prometheus.Collect
 			sess := session.Must(session.NewSession(config))
 			rdsSessions = append(rdsSessions, sess)
 		}
-		rdsExporter := pkg.NewRDSExporter(rdsSessions, logger, config.RdsConfig)
+		rdsExporter := pkg.NewRDSExporter(rdsSessions, logger, config.RdsConfig, awsAccountId)
 		collectors = append(collectors, rdsExporter)
 		go rdsExporter.CollectLoop()
 	}


### PR DESCRIPTION
APPSRE-8533

Adds AWS Account ID to the aws_resources_exporter_rds_engineversion metric.

Updates helper function in test to retrieve metric values from any label provided.