### PR TITLE
add missing max connections

### DIFF
--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -123,6 +123,10 @@ var DBMaxConnections = map[string]map[string]int64{
 		"default.postgres13": 5000,
 		"default.postgres14": 5000,
 	},
+	"db.m5.16xlarge": map[string]int64{
+		"default":                 6000,
+		"default.aurora-mysql5.7": 6000,
+	},
 	"db.m5d.large": map[string]int64{
 		"default":            823,
 		"default.postgres11": 823,


### PR DESCRIPTION
Fixing open rdsmaxconnectionsmapping alert

Values taken from https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html