### PR TITLE
Fix typo in OpenShift Template

### DIFF
--- a/openshift/aws-resource-exporter.yaml
+++ b/openshift/aws-resource-exporter.yaml
@@ -106,7 +106,7 @@ objects:
       app: ${NAME}
     name: ${CONFIGMAP_NAME}
   data:
-    aws-resource-exporter-config.yaml: ${AWS_RESOURE_EXPORTER_CONFIGURATION}
+    aws-resource-exporter-config.yaml: ${AWS_RESOURCE_EXPORTER_CONFIGURATION}
 parameters:
 - name: NAME
   value: aws-resource-exporter


### PR DESCRIPTION
There's a typo here meaning that the `ConfigMap` data will never be substituted correctly.