### PR TITLE
Add support for ingesting GovCloud metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,8 +61,14 @@ func setupCollectors(logger log.Logger, configFile string) ([]prometheus.Collect
 	level.Info(logger).Log("msg", "Configuring route53 with region", "region", config.Route53Config.Region)
 	level.Info(logger).Log("msg", "Configuring elasticache with regions", "regions", strings.Join(config.ElastiCacheConfig.Regions, ","))
 	level.Info(logger).Log("msg", "Will VPC metrics be gathered?", "vpc-enabled", config.VpcConfig.Enabled)
+
+	sessionRegion := "us-east-1"
+	if sr := os.Getenv("AWS_REGION"); sr != "" {
+		sessionRegion = sr
+	}
+
 	// Create a single session here, because we need the accountid, before we create the other configs
-	awsConfig := aws.NewConfig().WithRegion("us-east-1")
+	awsConfig := aws.NewConfig().WithRegion(sessionRegion)
 	sess := session.Must(session.NewSession(awsConfig))
 	awsAccountId, err := getAwsAccountNumber(logger, sess)
 	if err != nil {

--- a/openshift/aws-resource-exporter.yaml
+++ b/openshift/aws-resource-exporter.yaml
@@ -120,6 +120,7 @@ parameters:
   value: aws-resource-exporter
 - name: AWS_REGION
   value: us-east-1
+  description: if in GovCloud, use us-gov-east-1/us-gov-west-1
 - name: CONFIGMAP_NAME
   value: aws-resource-exporter-config
 - name: CPU_REQUESTS


### PR DESCRIPTION
[APPSRE-8668](https://issues.redhat.com/browse/APPSRE-8668)

The config is hardcoded to setup an initial session in us-east-1 which fails if you're trying to ingest metrics from other AWS partitions like GovCloud. This change updates the config to use the `AWS_REGION` env variable to setup the initial session. Validated locally that this change will allow us to ingest metrics in GovCloud AWS accounts, useful for FedRamp.