### PR TITLE
remove hardcoded rds eol thresholds

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -19,14 +19,14 @@ type BaseConfig struct {
 
 type RDSConfig struct {
 	BaseConfig `yaml:"base,inline"`
-	Regions    []string     `yaml:"regions"`
-	EOLInfos   []EOLInfo    `yaml:"eol_info"`
-	Thresholds []Thresholds `yaml:"thresholds"`
+	Regions    []string    `yaml:"regions"`
+	EOLInfos   []EOLInfo   `yaml:"eol_info"`
+	Thresholds []Threshold `yaml:"thresholds"`
 }
 
-type Thresholds struct {
-	Name      string `yaml:"name"`
-	Threshold int    `yaml:"threshold"`
+type Threshold struct {
+	Name string `yaml:"name"`
+	Days int    `yaml:"days"`
 }
 
 type EOLInfo struct {
@@ -127,10 +127,10 @@ func LoadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 
 	// Setting defaults when threshold is not defined to ease the transition from hardcoded thresholds
 	if len(config.RdsConfig.Thresholds) == 0 {
-		config.RdsConfig.Thresholds = []Thresholds{
-			{Name: "red", Threshold: 90},
-			{Name: "yellow", Threshold: 180},
-			{Name: "green", Threshold: 365},
+		config.RdsConfig.Thresholds = []Threshold{
+			{Name: "red", Days: 90},
+			{Name: "yellow", Days: 180},
+			{Name: "green", Days: 365},
 		}
 	}
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -19,8 +19,14 @@ type BaseConfig struct {
 
 type RDSConfig struct {
 	BaseConfig `yaml:"base,inline"`
-	Regions    []string  `yaml:"regions"`
-	EOLInfos   []EOLInfo `yaml:"eol_info"`
+	Regions    []string    `yaml:"regions"`
+	EOLInfos   []EOLInfo   `yaml:"eol_info"`
+	Thresholds []Threshold `yaml:"thresholds"`
+}
+
+type Threshold struct {
+	Name      string `yaml:"name"`
+	Threshold int    `yaml:"threshold"`
 }
 
 type EOLInfo struct {
@@ -117,6 +123,15 @@ func LoadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 	}
 	if config.ElastiCacheConfig.Timeout == nil {
 		config.ElastiCacheConfig.Timeout = durationPtr(10 * time.Second)
+	}
+
+	// Setting defaults when threshold is not defined to ease the transition from hardcoded thresholds
+	if len(config.RdsConfig.Thresholds) == 0 {
+		config.RdsConfig.Thresholds = []Threshold{
+			{Name: "red", Threshold: 90},
+			{Name: "yellow", Threshold: 180},
+			{Name: "green", Threshold: 365},
+		}
 	}
 
 	return &config, nil

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -19,12 +19,12 @@ type BaseConfig struct {
 
 type RDSConfig struct {
 	BaseConfig `yaml:"base,inline"`
-	Regions    []string    `yaml:"regions"`
-	EOLInfos   []EOLInfo   `yaml:"eol_info"`
-	Thresholds []Threshold `yaml:"thresholds"`
+	Regions    []string     `yaml:"regions"`
+	EOLInfos   []EOLInfo    `yaml:"eol_info"`
+	Thresholds []Thresholds `yaml:"thresholds"`
 }
 
-type Threshold struct {
+type Thresholds struct {
 	Name      string `yaml:"name"`
 	Threshold int    `yaml:"threshold"`
 }
@@ -127,7 +127,7 @@ func LoadExporterConfiguration(logger log.Logger, configFile string) (*Config, e
 
 	// Setting defaults when threshold is not defined to ease the transition from hardcoded thresholds
 	if len(config.RdsConfig.Thresholds) == 0 {
-		config.RdsConfig.Thresholds = []Threshold{
+		config.RdsConfig.Thresholds = []Thresholds{
 			{Name: "red", Threshold: 90},
 			{Name: "yellow", Threshold: 180},
 			{Name: "green", Threshold: 365},

--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -392,7 +392,7 @@ type RDSExporter struct {
 	sessions     []*session.Session
 	svcs         []awsclient.Client
 	eolInfos     []EOLInfo
-	thresholds   []Threshold
+	thresholds   []Thresholds
 	awsAccountId string
 
 	workers        int
@@ -588,7 +588,7 @@ func (e *RDSExporter) addAllInstanceMetrics(sessionIndex int, instances []*rds.D
 }
 
 // Determines status from the number of days until EOL
-func (e *RDSExporter) getEOLStatus(eol string, thresholds []Threshold) (string, error) {
+func (e *RDSExporter) getEOLStatus(eol string, thresholds []Thresholds) (string, error) {
 	eolDate, err := time.Parse("2006-01-02", eol)
 	if err != nil {
 		return "", err

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -99,7 +99,7 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 }
 
 func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {
-	thresholds := []Threshold{
+	thresholds := []Thresholds{
 		{Name: "red", Threshold: 90},
 		{Name: "yellow", Threshold: 180},
 		{Name: "green", Threshold: 365},
@@ -165,7 +165,7 @@ func TestGetEOLStatus(t *testing.T) {
 		logger:   log.NewNopLogger(),
 	}
 
-	thresholds := []Threshold{
+	thresholds := []Thresholds{
 		{Name: "red", Threshold: 90},
 		{Name: "yellow", Threshold: 180},
 		{Name: "green", Threshold: 365},

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -214,6 +214,17 @@ func TestGetEOLStatus(t *testing.T) {
 	if status != expectedStatus {
 		t.Errorf("Expected status '%s', but got '%s'", expectedStatus, status)
 	}
+
+	//Thresholds is empty
+	eol = time.Now().Add(30 * 24 * time.Hour).Format("2006-01-02")
+	emptyThresholds := []Threshold{}
+	status, err = x.getEOLStatus(eol, emptyThresholds)
+	if err == nil {
+		t.Errorf("Expected an error for empty thresholds, but got none")
+	}
+	if status != "" {
+		t.Errorf("Expected no status for empty thresholds, but got '%s'", status)
+	}
 }
 
 func TestEngineVersionMetricIncludesAWSAccountId(t *testing.T) {

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -99,10 +99,10 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 }
 
 func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {
-	thresholds := []Thresholds{
-		{Name: "red", Threshold: 90},
-		{Name: "yellow", Threshold: 180},
-		{Name: "green", Threshold: 365},
+	thresholds := []Threshold{
+		{Name: "red", Days: 90},
+		{Name: "yellow", Days: 180},
+		{Name: "green", Days: 365},
 	}
 
 	x := RDSExporter{
@@ -165,10 +165,10 @@ func TestGetEOLStatus(t *testing.T) {
 		logger:   log.NewNopLogger(),
 	}
 
-	thresholds := []Thresholds{
-		{Name: "red", Threshold: 90},
-		{Name: "yellow", Threshold: 180},
-		{Name: "green", Threshold: 365},
+	thresholds := []Threshold{
+		{Name: "red", Days: 90},
+		{Name: "yellow", Days: 180},
+		{Name: "green", Days: 365},
 	}
 
 	// EOL date is within 90 days
@@ -204,6 +204,16 @@ func TestGetEOLStatus(t *testing.T) {
 		t.Errorf("Expected status '%s', but got '%s'", expectedStatus, status)
 	}
 
+	//EOL date exceeds highest threshold
+	eol = time.Now().Add(400 * 24 * time.Hour).Format("2006-01-02")
+	expectedStatus = "green"
+	status, err = x.getEOLStatus(eol, thresholds)
+	if err != nil {
+		t.Errorf("Expected no error, but got an error: %v", err)
+	}
+	if status != expectedStatus {
+		t.Errorf("Expected status '%s', but got '%s'", expectedStatus, status)
+	}
 }
 
 func TestEngineVersionMetricIncludesAWSAccountId(t *testing.T) {


### PR DESCRIPTION
APPSRE-8636

Removes hardcoded rds eol thresholds, and instead gets thresholds from the configmap.

Adds default threshold values when loading config to avoid the alerts flapping and the tickets getting regenerated during the transition. 