### PR TITLE
Add green msk eol status if msk eol not found

### DIFF
--- a/pkg/msk.go
+++ b/pkg/msk.go
@@ -78,7 +78,7 @@ func (e *MSKExporter) addMetricFromMSKInfo(sessionIndex int, clusters []*kafka.C
 			}
 			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, eolDate, eolStatus))
 		} else {
-			level.Error(e.logger).Log("msg", "EOL information not found for MSK version %s, setting status to 'green'", mskVersion)
+			level.Info(e.logger).Log("msg", "EOL information not found for MSK version %s, setting status to 'green'", mskVersion)
 			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, "no-eol-date", "green"))
 		}
 	}

--- a/pkg/msk.go
+++ b/pkg/msk.go
@@ -78,7 +78,7 @@ func (e *MSKExporter) addMetricFromMSKInfo(sessionIndex int, clusters []*kafka.C
 			}
 			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, eolDate, eolStatus))
 		} else {
-			level.Error(e.logger).Log("msg", "EOL information not found for MSK version, setting status to 'green'", "version", mskVersion)
+			level.Error(e.logger).Log("msg", "EOL information not found for MSK version %s, setting status to 'green'", mskVersion)
 			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, "no-eol-date", "green"))
 		}
 	}

--- a/pkg/msk.go
+++ b/pkg/msk.go
@@ -78,7 +78,8 @@ func (e *MSKExporter) addMetricFromMSKInfo(sessionIndex int, clusters []*kafka.C
 			}
 			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, eolDate, eolStatus))
 		} else {
-			level.Error(e.logger).Log("msg", "EOL information not found for MSK version", "version", mskVersion)
+			level.Error(e.logger).Log("msg", "EOL information not found for MSK version, setting status to 'green'", "version", mskVersion)
+			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, "no-eol-date", "green"))
 		}
 	}
 }

--- a/pkg/msk.go
+++ b/pkg/msk.go
@@ -78,8 +78,8 @@ func (e *MSKExporter) addMetricFromMSKInfo(sessionIndex int, clusters []*kafka.C
 			}
 			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, eolDate, eolStatus))
 		} else {
-			level.Info(e.logger).Log("msg", "EOL information not found for MSK version %s, setting status to 'green'", mskVersion)
-			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, "no-eol-date", "green"))
+			level.Info(e.logger).Log("msg", "EOL information not found for MSK version %s, setting status to 'unknown'", mskVersion)
+			e.cache.AddMetric(prometheus.MustNewConstMetric(MSKInfos, prometheus.GaugeValue, 1, region, clusterName, mskVersion, "no-eol-date", "unknown"))
 		}
 	}
 }


### PR DESCRIPTION
APPSRE-9953

Some of the versions don't have an EOL date -  https://docs.aws.amazon.com/msk/latest/developerguide/supported-kafka-versions.html

This will set the eol status to green when a version/eol match is not found.