### PR TITLE
more instance types

### DIFF
--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -317,6 +317,12 @@ var DBMaxConnections = map[string]map[string]int64{
 	//
 	// R6
 	//
+    "db.r6g.8xlarge": map[string]int64{
+		// Memory: 256 GiB
+		"default":          5000,
+		"default.mysql5.7": 262143,
+		"default.mysql8.0": 262143,
+	},
 	"db.r6g.12xlarge": map[string]int64{
 		// Memory: 384 GiB
 		"default":          5000,


### PR DESCRIPTION
Values taken from query on postgres instance:

```
SELECT * FROM pg_settings WHERE name = 'max_connections';                                                                                                                        
      name       | setting | unit |                       category                       |                     short_desc                     | extra_desc |  context   | vartype |       source       | mi
n_val | max_val | enumvals | boot_val | reset_val |            sourcefile             | sourceline | pending_restart                                                                                       
-----------------+---------+------+------------------------------------------------------+----------------------------------------------------+------------+------------+---------+--------------------+---
------+---------+----------+----------+-----------+-----------------------------------+------------+-----------------                                                                                      
 max_connections | 5000    |      | Connections and Authentication / Connection Settings | Sets the maximum number of concurrent connections. |            | postmaster | integer | configuration file | 1 
      | 262143  |          | 100      | 5000      | /rdsdbdata/config/postgresql.conf |         55 | f                                                                                                     
(1 row)
```