### PR TITLE
fix(elasticache): resolve engine label to valkey for versions >= 7.2

### DIFF
--- a/pkg/elasticache.go
+++ b/pkg/elasticache.go
@@ -3,6 +3,8 @@ package pkg
 import (
 	"context"
 	"log/slog"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/app-sre/aws-resource-exporter/pkg/awsclient"
@@ -53,6 +55,33 @@ func (e *ElastiCacheExporter) getRegion(configIndex int) string {
 	return e.configs[configIndex].Region
 }
 
+// resolveElastiCacheEngine normalizes the engine label for ElastiCache metrics.
+// AWS ElastiCache Valkey starts at version 7.2. Clusters that were migrated
+// in-place from Redis to Valkey may still report Engine="redis" in the AWS API
+// while actually running Valkey. This function uses the version as the
+// definitive signal: major >= 7 and minor >= 2 means Valkey.
+func resolveElastiCacheEngine(reportedEngine, engineVersion string) string {
+	if reportedEngine == "valkey" {
+		return "valkey"
+	}
+	parts := strings.SplitN(engineVersion, ".", 3)
+	if len(parts) < 2 {
+		return reportedEngine
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return reportedEngine
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return reportedEngine
+	}
+	if major > 7 || (major == 7 && minor >= 2) {
+		return "valkey"
+	}
+	return reportedEngine
+}
+
 // Adds ElastiCache info to metrics cache
 func (e *ElastiCacheExporter) addMetricFromElastiCacheInfo(configIndex int, clusters []elasticache_types.CacheCluster) {
 	region := e.getRegion(configIndex)
@@ -70,6 +99,8 @@ func (e *ElastiCacheExporter) addMetricFromElastiCacheInfo(configIndex int, clus
 		if cluster.EngineVersion != nil {
 			engineVersion = *cluster.EngineVersion
 		}
+
+		engine = resolveElastiCacheEngine(engine, engineVersion)
 
 		e.cache.AddMetric(prometheus.MustNewConstMetric(RedisVersion, prometheus.GaugeValue, 1, region, replicationGroupId, engine, engineVersion, e.awsAccountId))
 	}

--- a/pkg/elasticache_test.go
+++ b/pkg/elasticache_test.go
@@ -16,7 +16,18 @@ func createTestCacheClusters() []elasticache_types.CacheCluster {
 		{
 			CacheClusterId: aws.String("test-cluster"),
 			Engine:         aws.String("redis"),
-			EngineVersion:  aws.String("123"),
+			EngineVersion:  aws.String("6.2"),
+		},
+	}
+}
+
+func createTestCacheClustersValkey() []elasticache_types.CacheCluster {
+	return []elasticache_types.CacheCluster{
+		{
+			CacheClusterId:     aws.String("valkey-cluster"),
+			ReplicationGroupId: aws.String("valkey-rg"),
+			Engine:             aws.String("redis"),
+			EngineVersion:      aws.String("7.2"),
 		},
 	}
 }
@@ -35,4 +46,43 @@ func TestAddMetricFromElastiCacheInfo(t *testing.T) {
 
 	x.addMetricFromElastiCacheInfo(0, createTestCacheClusters())
 	assert.Len(t, x.cache.GetAllMetrics(), 1)
+}
+
+func TestAddMetricFromElastiCacheInfoValkey(t *testing.T) {
+	x := ElastiCacheExporter{
+		configs: []aws.Config{{Region: "us-east-1"}},
+		cache:   *NewMetricsCache(10 * time.Second),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	x.addMetricFromElastiCacheInfo(0, createTestCacheClustersValkey())
+	assert.Len(t, x.cache.GetAllMetrics(), 1)
+}
+
+func TestResolveElastiCacheEngine(t *testing.T) {
+	tests := []struct {
+		name           string
+		reportedEngine string
+		engineVersion  string
+		expected       string
+	}{
+		{"redis 6.2 stays redis", "redis", "6.2", "redis"},
+		{"redis 7.1 stays redis", "redis", "7.1", "redis"},
+		{"redis 7.2 becomes valkey", "redis", "7.2", "valkey"},
+		{"redis 7.3 becomes valkey", "redis", "7.3", "valkey"},
+		{"redis 8.0 becomes valkey", "redis", "8.0", "valkey"},
+		{"valkey 7.2 stays valkey", "valkey", "7.2", "valkey"},
+		{"valkey 8.0 stays valkey", "valkey", "8.0", "valkey"},
+		{"invalid version keeps reported", "redis", "invalid", "redis"},
+		{"empty version keeps reported", "redis", "", "redis"},
+		{"major only redis 6", "redis", "6", "redis"},
+		{"patch version 7.2.1 becomes valkey", "redis", "7.2.1", "valkey"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveElastiCacheEngine(tt.reportedEngine, tt.engineVersion)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Add `resolveElastiCacheEngine()` function that normalizes the `engine` metric label for ElastiCache clusters
- Clusters running version >= 7.2 are reported as `engine="valkey"` regardless of what the AWS `DescribeCacheClusters` API returns
- AWS clusters migrated in-place from Redis to Valkey may still report `Engine: "redis"` in the API, causing downstream consumers (aws-version-sync, dashboards, alerts) to receive incorrect engine labels

## Context

- **Jira:** [APPSRE-14128](https://redhat.atlassian.net/browse/APPSRE-14128)
- **Root cause:** AVS opened GitLab MR !186963 with `engine_version: '6.2'` while ERV2 validation saw Valkey (requires >= 7.2), causing CI failure
- **This PR fixes the source:** metrics now emit the correct engine label so all consumers get truth from Prometheus

## Changes

- `pkg/elasticache.go`: Added `resolveElastiCacheEngine()` and call it in `addMetricFromElastiCacheInfo()` before emitting metrics
- `pkg/elasticache_test.go`: Added table-driven tests for the resolver and a Valkey cluster fixture

## Test plan

- [x] `go test ./pkg/ -v` passes (all existing + new tests)
- [ ] Deploy to staging and verify Valkey clusters emit `engine="valkey"` in metrics
- [ ] Confirm AVS picks up correct engine from metrics after deployment