### PR TITLE
ROSAENG-61543: add flag to route53 exporter to skip the HostedZoneLimit fetch

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -44,8 +44,9 @@ type VPCConfig struct {
 }
 
 type Route53Config struct {
-	BaseConfig `yaml:"base,inline"`
-	Region     string `yaml:"region"` // Use only a single Region for now, as the current metric is global
+	BaseConfig    `yaml:"base,inline"`
+	Region        string `yaml:"region"` // Use only a single Region for now, as the current metric is global
+	SkipZoneLimit bool   `yaml:"skip_zone_limit"`
 }
 
 type EC2Config struct {

--- a/pkg/route53.go
+++ b/pkg/route53.go
@@ -36,10 +36,11 @@ type Route53Exporter struct {
 	LastUpdateTime             *prometheus.Desc
 	Cancel                     context.CancelFunc
 
-	cache    MetricsCache
-	logger   *slog.Logger
-	interval time.Duration
-	timeout  time.Duration
+	cache         MetricsCache
+	logger        *slog.Logger
+	interval      time.Duration
+	timeout       time.Duration
+	skipZoneLimit bool
 }
 
 func NewRoute53Exporter(cfg aws.Config, logger *slog.Logger, config Route53Config, awsAccountId string) *Route53Exporter {
@@ -58,6 +59,7 @@ func NewRoute53Exporter(cfg aws.Config, logger *slog.Logger, config Route53Confi
 		logger:                     logger,
 		interval:                   *config.Interval,
 		timeout:                    *config.Timeout,
+		skipZoneLimit:              config.SkipZoneLimit,
 	}
 	return exporter
 }
@@ -136,10 +138,14 @@ func (e *Route53Exporter) CollectLoop() {
 			awsclient.AwsExporterMetrics.IncrementErrors()
 		}
 
-		errs := e.getRecordsPerHostedZoneMetrics(client, hostedZones, ctx)
-		for _, err = range errs {
-			e.logger.Error("Could not get limits for hosted zone", "error", err.Error())
-			awsclient.AwsExporterMetrics.IncrementErrors()
+		if e.skipZoneLimit {
+			e.logger.Info("Skipping per-zone limit metrics (skip_zone_limit is enabled)")
+		} else {
+			errs := e.getRecordsPerHostedZoneMetrics(client, hostedZones, ctx)
+			for _, err = range errs {
+				e.logger.Error("Could not get limits for hosted zone", "error", err.Error())
+				awsclient.AwsExporterMetrics.IncrementErrors()
+			}
 		}
 
 		e.logger.Info("Route53 metrics Updated")


### PR DESCRIPTION
For some of the aws account, they may have thousands of hosted zones.

Which the per-hostedzone level metric will create thousands of API request to AWS in each iteration.

And easily the AWS account hit the rate limit and being throttled, which will impact the real workload running depends on the AWS account.