### PR TITLE
fix(rds): add db.m9g.large to DBMaxConnections mapping

### DIFF
--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -320,8 +320,8 @@ var DBMaxConnections = map[string]map[string]int64{
 	// M9g
 	//
 	"db.m9g.large": map[string]int64{
-		// Memory: 8 GiB (pattern-derived from m5/m6g/m7g/m8g .large, all 8 GiB;
-		// not yet confirmed against a live instance via pg_settings/SHOW VARIABLES)
+		// Memory: 8 GiB (2 vCPU / 8 GiB per https://instances.vantage.sh/aws/ec2/m9g.large,
+		// consistent with every prior M-family .large generation in this table)
 		"default":          900,
 		"default.mysql5.7": 600,
 		"default.mysql8.0": 600,

--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -317,6 +317,17 @@ var DBMaxConnections = map[string]map[string]int64{
 	},
 
 	//
+	// M9g
+	//
+	"db.m9g.large": map[string]int64{
+		// Memory: 8 GiB (pattern-derived from m5/m6g/m7g/m8g .large, all 8 GiB;
+		// not yet confirmed against a live instance via pg_settings/SHOW VARIABLES)
+		"default":          900,
+		"default.mysql5.7": 600,
+		"default.mysql8.0": 600,
+	},
+
+	//
 	// R5
 	//
 	"db.r5.large": map[string]int64{


### PR DESCRIPTION
Fixes RDSMaxConnectionsMapping firing for ocp-vulnerability-prod's blue/green target on db.m9g.large