### PR TITLE
fix(rds): add db.m9g.2xlarge to DBMaxConnections mapping

### DIFF
--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -326,6 +326,13 @@ var DBMaxConnections = map[string]map[string]int64{
 		"default.mysql5.7": 600,
 		"default.mysql8.0": 600,
 	},
+	"db.m9g.2xlarge": map[string]int64{
+		// Memory: 32 GiB (8 vCPU / 32 GiB per https://instances.vantage.sh/aws/ec2/m9g.2xlarge,
+		// consistent with every prior M-family .2xlarge generation in this table)
+		"default":          3600,
+		"default.mysql5.7": 2600,
+		"default.mysql8.0": 2600,
+	},
 
 	//
 	// R5


### PR DESCRIPTION
## Summary
- Adds `db.m9g.2xlarge` to the `DBMaxConnections` mapping in `pkg/rds.go`, following up on the existing `db.m9g.large` entry
- Uses the same values as `db.m8g.2xlarge` since memory (32 GiB) and vCPU count are identical between the M8g and M9g generations at this size

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/...`