### PR TITLE
fix(rds): mark eol_status=red when engine version is missing from eol_info config

### DIFF
--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -739,6 +739,7 @@ func (e *RDSExporter) addAllInstanceMetrics(configIndex int, instances []rds_typ
 			e.logger.Info("RDS EOL not found for engine version",
 				slog.String("engine", *instance.Engine),
 				slog.String("version", *instance.EngineVersion))
+			e.cache.AddMetric(prometheus.MustNewConstMetric(EOLInfos, prometheus.GaugeValue, 1, e.getRegion(configIndex), *instance.DBInstanceIdentifier, *instance.Engine, *instance.EngineVersion, "no-eol-date", "red"))
 		}
 
 		var public = 0.0

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -96,7 +96,38 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 	assert.Len(t, x.cache.GetAllMetrics(), 0)
 
 	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
-	assert.Len(t, x.cache.GetAllMetrics(), 9)
+	assert.Len(t, x.cache.GetAllMetrics(), 10)
+}
+
+func TestAddAllInstanceMetricsWithEOLMiss(t *testing.T) {
+	x := RDSExporter{
+		configs: []aws.Config{{Region: "foo"}},
+		cache:   *NewMetricsCache(10 * time.Second),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	// eolInfos has no entry matching the test instance's engine/version
+	eolInfos := []EOLInfo{
+		{Engine: "engine", Version: "123", EOL: "2023-12-01"},
+	}
+
+	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
+
+	labels, err := getMetricLabels(&x, EOLInfos, "eol_date", "eol_status")
+	if err != nil {
+		t.Errorf("Error retrieving EOL labels: %v", err)
+	}
+
+	expectedEOLDate := "no-eol-date"
+	expectedEOLStatus := "red"
+
+	if eolDate, ok := labels["eol_date"]; !ok || eolDate != expectedEOLDate {
+		t.Errorf("EOLDate metric has an unexpected value. Expected: %s, Actual: %s", expectedEOLDate, eolDate)
+	}
+
+	if eolStatus, ok := labels["eol_status"]; !ok || eolStatus != expectedEOLStatus {
+		t.Errorf("EOLStatus metric has an unexpected value. Expected: %s, Actual: %s", expectedEOLStatus, eolStatus)
+	}
 }
 
 func TestAddAllInstanceMetricsWithEOLMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- `cloudigrade-prod` was auto-upgraded by AWS to engine version `13.23-rds.20260224`, which isn't in the exporter's `eol_info` config. On a lookup miss, `addAllInstanceMetrics` only logged a message and silently skipped emitting `aws_resources_exporter_rds_eol_info` for that instance, so no EOL alert could ever fire for it.
- Since AWS retires old engine versions from its docs faster than `eol_info` gets updated, any missing version is now surfaced as `eol_status="red"` (with `eol_date="no-eol-date"`) instead of being dropped, so it flows through the normal alerting path.
- Discussed in Slack: https://redhat-internal.slack.com/archives/C098G63A9JQ/p1786542346113909
- Jira: APPSRE-15071

## Test plan
- [x] Added `TestAddAllInstanceMetricsWithEOLMiss` asserting `eol_status="red"` / `eol_date="no-eol-date"` on a lookup miss
- [x] Updated `TestAddAllInstanceMetrics` expected metric count (9 -> 10) now that the miss case emits a metric
- [x] `make test-unit` and `go vet ./...` pass