### PR TITLE
fix(rds): add standard R6 max connection mappings

### DIFF
--- a/pkg/rds.go
+++ b/pkg/rds.go
@@ -40,6 +40,7 @@ var metricsProxy = NewMetricProxy()
 // This is a dump workaround created because by default the DB Parameter Group `max_connections` is a function
 // that is hard to parse and process in code and it contains a variable whose value is unknown to us (DBInstanceClassMemory)
 // AWS has no means to return the actual `max_connections` value.
+// The values below are expected defaults; custom parameter-group overrides are not resolved here.
 
 // Non Aurora: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections
 // DBInstanceClassMemory in bytes: Memory (in GiB) * 1024 * 1024 * 1024
@@ -431,15 +432,9 @@ var DBMaxConnections = map[string]map[string]int64{
 	},
 
 	//
-	// R6
+	// R6g
 	//
-	"db.r6g.12xlarge": map[string]int64{
-		// Memory: 384 GiB
-		"default":          5000,
-		"default.mysql5.7": 32700,
-		"default.mysql8.0": 32700,
-	},
-	"db.r6i.large": map[string]int64{
+	"db.r6g.large": map[string]int64{
 		// Memory: 16 GiB
 		"default":          1800,
 		"default.mysql5.7": 1300,
@@ -447,7 +442,79 @@ var DBMaxConnections = map[string]map[string]int64{
 	},
 	"db.r6g.xlarge": map[string]int64{
 		// Memory: 32 GiB
-		"default": 3484,
+		"default":          3600,
+		"default.mysql5.7": 2600,
+		"default.mysql8.0": 2600,
+	},
+	"db.r6g.2xlarge": map[string]int64{
+		// Memory: 64 GiB
+		"default":          5000,
+		"default.mysql5.7": 5300,
+		"default.mysql8.0": 5300,
+	},
+	"db.r6g.4xlarge": map[string]int64{
+		// Memory: 128 GiB
+		"default":          5000,
+		"default.mysql5.7": 10700,
+		"default.mysql8.0": 10700,
+	},
+	"db.r6g.8xlarge": map[string]int64{
+		// Memory: 256 GiB
+		"default":          5000,
+		"default.mysql5.7": 21600,
+		"default.mysql8.0": 21600,
+	},
+	"db.r6g.12xlarge": map[string]int64{
+		// Memory: 384 GiB
+		"default":          5000,
+		"default.mysql5.7": 32700,
+		"default.mysql8.0": 32700,
+	},
+	"db.r6g.16xlarge": map[string]int64{
+		// Memory: 512 GiB
+		"default":          5000,
+		"default.mysql5.7": 43400,
+		"default.mysql8.0": 43400,
+	},
+
+	//
+	// R6i
+	//
+	"db.r6i.large": map[string]int64{
+		// Memory: 16 GiB
+		"default":          1800,
+		"default.mysql5.7": 1300,
+		"default.mysql8.0": 1300,
+	},
+	"db.r6i.xlarge": map[string]int64{
+		// Memory: 32 GiB
+		"default":          3600,
+		"default.mysql5.7": 2600,
+		"default.mysql8.0": 2600,
+	},
+	"db.r6i.2xlarge": map[string]int64{
+		// Memory: 64 GiB
+		"default":          5000,
+		"default.mysql5.7": 5300,
+		"default.mysql8.0": 5300,
+	},
+	"db.r6i.4xlarge": map[string]int64{
+		// Memory: 128 GiB
+		"default":          5000,
+		"default.mysql5.7": 10700,
+		"default.mysql8.0": 10700,
+	},
+	"db.r6i.8xlarge": map[string]int64{
+		// Memory: 256 GiB
+		"default":          5000,
+		"default.mysql5.7": 21600,
+		"default.mysql8.0": 21600,
+	},
+	"db.r6i.12xlarge": map[string]int64{
+		// Memory: 384 GiB
+		"default":          5000,
+		"default.mysql5.7": 32700,
+		"default.mysql8.0": 32700,
 	},
 	"db.r6i.16xlarge": map[string]int64{
 		// Memory: 512 GiB
@@ -457,13 +524,15 @@ var DBMaxConnections = map[string]map[string]int64{
 	},
 	"db.r6i.24xlarge": map[string]int64{
 		// Memory: 768 GiB
-		"default": 5000,
-	},
-	"db.r6g.8xlarge": map[string]int64{
-		// Memory: 256 GiB
 		"default":          5000,
-		"default.mysql5.7": 21600,
-		"default.mysql8.0": 21600,
+		"default.mysql5.7": 65400,
+		"default.mysql8.0": 65400,
+	},
+	"db.r6i.32xlarge": map[string]int64{
+		// Memory: 1024 GiB
+		"default":          5000,
+		"default.mysql5.7": 87300,
+		"default.mysql8.0": 87300,
 	},
 
 	//

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"strings"
 	"testing"
 	"time"
 
@@ -98,78 +97,6 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 
 	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
 	assert.Len(t, x.cache.GetAllMetrics(), 10)
-}
-
-func TestDBMaxConnectionsR6Mappings(t *testing.T) {
-	expectedClasses := []string{
-		"db.r6g.large",
-		"db.r6g.xlarge",
-		"db.r6g.2xlarge",
-		"db.r6g.4xlarge",
-		"db.r6g.8xlarge",
-		"db.r6g.12xlarge",
-		"db.r6g.16xlarge",
-		"db.r6i.large",
-		"db.r6i.xlarge",
-		"db.r6i.2xlarge",
-		"db.r6i.4xlarge",
-		"db.r6i.8xlarge",
-		"db.r6i.12xlarge",
-		"db.r6i.16xlarge",
-		"db.r6i.24xlarge",
-		"db.r6i.32xlarge",
-	}
-	parameterGroups := []string{"default", "default.mysql5.7", "default.mysql8.0"}
-
-	var actualClasses []string
-	for class := range DBMaxConnections {
-		if strings.HasPrefix(class, "db.r6g.") || strings.HasPrefix(class, "db.r6i.") {
-			actualClasses = append(actualClasses, class)
-		}
-	}
-
-	assert.Len(t, expectedClasses, 16)
-	assert.Len(t, actualClasses, len(expectedClasses))
-	assert.ElementsMatch(t, expectedClasses, actualClasses)
-	for _, class := range expectedClasses {
-		t.Run(class, func(t *testing.T) {
-			mapping, ok := DBMaxConnections[class]
-			if !assert.True(t, ok) {
-				return
-			}
-			assert.Len(t, mapping, len(parameterGroups))
-			for _, parameterGroup := range parameterGroups {
-				assert.Contains(t, mapping, parameterGroup)
-			}
-		})
-	}
-}
-
-func TestR6MaxConnectionsMetric(t *testing.T) {
-	x := RDSExporter{
-		configs: []aws.Config{{Region: "foo"}},
-		cache:   *NewMetricsCache(10 * time.Second),
-		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}
-
-	x.addAllInstanceMetrics(0, []rds_types.DBInstance{{
-		DBInstanceIdentifier: aws.String("r6itest"),
-		DBInstanceClass:      aws.String("db.r6i.xlarge"),
-		DBParameterGroups:    []rds_types.DBParameterGroupStatus{{DBParameterGroupName: aws.String("default.postgres14")}},
-		PubliclyAccessible:   aws.Bool(false),
-		StorageEncrypted:     aws.Bool(false),
-		AllocatedStorage:     aws.Int32(100),
-		DBInstanceStatus:     aws.String("available"),
-		Engine:               aws.String("postgres"),
-		EngineVersion:        aws.String("14"),
-	}}, nil)
-
-	_, err := getMetricValue(&x, MaxConnections)
-	assert.NoError(t, err)
-
-	mappingError, err := getMetricValue(&x, MaxConnectionsMappingError)
-	assert.NoError(t, err)
-	assert.Equal(t, float64(0), mappingError)
 }
 
 func TestAddAllInstanceMetricsWithEOLMiss(t *testing.T) {
@@ -375,20 +302,6 @@ func getMetricLabels(x *RDSExporter, metricDesc *prometheus.Desc, labelNames ...
 		}
 	}
 	return nil, fmt.Errorf("metric not found")
-}
-
-func getMetricValue(x *RDSExporter, metricDesc *prometheus.Desc) (float64, error) {
-	metricDescription := metricDesc.String()
-	for _, metric := range x.cache.GetAllMetrics() {
-		if metric.Desc().String() == metricDescription {
-			dtoMetric := &dto.Metric{}
-			if err := metric.Write(dtoMetric); err != nil {
-				return 0, err
-			}
-			return dtoMetric.GetGauge().GetValue(), nil
-		}
-	}
-	return 0, fmt.Errorf("metric not found")
 }
 
 func TestAddAllPendingMaintenancesMetrics(t *testing.T) {

--- a/pkg/rds_test.go
+++ b/pkg/rds_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -97,6 +98,78 @@ func TestAddAllInstanceMetrics(t *testing.T) {
 
 	x.addAllInstanceMetrics(0, createTestDBInstances(), eolInfos)
 	assert.Len(t, x.cache.GetAllMetrics(), 10)
+}
+
+func TestDBMaxConnectionsR6Mappings(t *testing.T) {
+	expectedClasses := []string{
+		"db.r6g.large",
+		"db.r6g.xlarge",
+		"db.r6g.2xlarge",
+		"db.r6g.4xlarge",
+		"db.r6g.8xlarge",
+		"db.r6g.12xlarge",
+		"db.r6g.16xlarge",
+		"db.r6i.large",
+		"db.r6i.xlarge",
+		"db.r6i.2xlarge",
+		"db.r6i.4xlarge",
+		"db.r6i.8xlarge",
+		"db.r6i.12xlarge",
+		"db.r6i.16xlarge",
+		"db.r6i.24xlarge",
+		"db.r6i.32xlarge",
+	}
+	parameterGroups := []string{"default", "default.mysql5.7", "default.mysql8.0"}
+
+	var actualClasses []string
+	for class := range DBMaxConnections {
+		if strings.HasPrefix(class, "db.r6g.") || strings.HasPrefix(class, "db.r6i.") {
+			actualClasses = append(actualClasses, class)
+		}
+	}
+
+	assert.Len(t, expectedClasses, 16)
+	assert.Len(t, actualClasses, len(expectedClasses))
+	assert.ElementsMatch(t, expectedClasses, actualClasses)
+	for _, class := range expectedClasses {
+		t.Run(class, func(t *testing.T) {
+			mapping, ok := DBMaxConnections[class]
+			if !assert.True(t, ok) {
+				return
+			}
+			assert.Len(t, mapping, len(parameterGroups))
+			for _, parameterGroup := range parameterGroups {
+				assert.Contains(t, mapping, parameterGroup)
+			}
+		})
+	}
+}
+
+func TestR6MaxConnectionsMetric(t *testing.T) {
+	x := RDSExporter{
+		configs: []aws.Config{{Region: "foo"}},
+		cache:   *NewMetricsCache(10 * time.Second),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	x.addAllInstanceMetrics(0, []rds_types.DBInstance{{
+		DBInstanceIdentifier: aws.String("r6itest"),
+		DBInstanceClass:      aws.String("db.r6i.xlarge"),
+		DBParameterGroups:    []rds_types.DBParameterGroupStatus{{DBParameterGroupName: aws.String("default.postgres14")}},
+		PubliclyAccessible:   aws.Bool(false),
+		StorageEncrypted:     aws.Bool(false),
+		AllocatedStorage:     aws.Int32(100),
+		DBInstanceStatus:     aws.String("available"),
+		Engine:               aws.String("postgres"),
+		EngineVersion:        aws.String("14"),
+	}}, nil)
+
+	_, err := getMetricValue(&x, MaxConnections)
+	assert.NoError(t, err)
+
+	mappingError, err := getMetricValue(&x, MaxConnectionsMappingError)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), mappingError)
 }
 
 func TestAddAllInstanceMetricsWithEOLMiss(t *testing.T) {
@@ -302,6 +375,20 @@ func getMetricLabels(x *RDSExporter, metricDesc *prometheus.Desc, labelNames ...
 		}
 	}
 	return nil, fmt.Errorf("metric not found")
+}
+
+func getMetricValue(x *RDSExporter, metricDesc *prometheus.Desc) (float64, error) {
+	metricDescription := metricDesc.String()
+	for _, metric := range x.cache.GetAllMetrics() {
+		if metric.Desc().String() == metricDescription {
+			dtoMetric := &dto.Metric{}
+			if err := metric.Write(dtoMetric); err != nil {
+				return 0, err
+			}
+			return dtoMetric.GetGauge().GetValue(), nil
+		}
+	}
+	return 0, fmt.Errorf("metric not found")
 }
 
 func TestAddAllPendingMaintenancesMetrics(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add expected max_connections mappings for all 16 standard non-metal r6g and r6i RDS instance classes.
- Use 3600 for every 32-GiB PostgreSQL class, including db.r6g.xlarge.
- Keep the existing PostgreSQL and MySQL mapping keys for the supported engines.

## AWS behavior

AWS exposes the RDS max-connections formula and the current DatabaseConnections CloudWatch metric, but not the evaluated instance-level max_connections value. Because DBInstanceClassMemory is internal, the exporter maintains this expected-default map.

This change is limited to standard r6g and r6i classes. It does not add r6gd, r6id, r6in, metal, Oracle TPC, MariaDB, Aurora, or custom parameter-group handling.

## Verification

- go test ./pkg/...
- make test
- git diff --check

References: [RDS limits](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html), [parameter formulas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ParamValuesRef.html), and [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html).
